### PR TITLE
Fix memory leak in TabTray

### DIFF
--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
@@ -122,6 +122,7 @@ internal class TabsSessionModel(
         fun stopMonitorSessionChange() {
             this.tabTrayObserver = null
             stopMonitorSessionManager()
+            stopMonitorSession()
         }
 
         override fun onSessionCountChanged(count: Int) {


### PR DESCRIPTION
When switching session in TabTray, a observer might register to a session without unregister, which cause a memory leak