### PR TITLE
Refactor browser fragment by spliting logic into controllers

### DIFF
--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -376,7 +376,7 @@ class MainActivity :
             share.observe(
                 this@MainActivity,
                 Observer {
-                    visibleBrowserFragment?.let { shareText(it.url) }
+                    visibleBrowserFragment?.let { shareText(it.chromeUrl) }
                 }
             )
             showDownloadPanel.observe(

--- a/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -454,7 +454,7 @@ class MainActivity :
                                 }
                             }
                         }
-                        anchorView = browserFragment?.binding?.browserBottomBar
+                        anchorView = browserFragment?.getSnackBarAnchor()
                         show()
                     }
                 }
@@ -758,7 +758,7 @@ class MainActivity :
                     )
                 )
             }
-            anchorView = browserFragment?.binding?.browserBottomBar
+            anchorView = browserFragment?.getSnackBarAnchor()
         }.show()
     }
 

--- a/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
+++ b/app/src/main/java/org/mozilla/focus/tabs/tabtray/TabsSessionModel.kt
@@ -6,14 +6,9 @@
 package org.mozilla.focus.tabs.tabtray
 
 import android.graphics.Bitmap
-import android.net.Uri
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
 import org.mozilla.focus.BuildConfig
 import org.mozilla.rocket.tabs.Session
 import org.mozilla.rocket.tabs.SessionManager
-import org.mozilla.rocket.tabs.TabViewClient
-import org.mozilla.rocket.tabs.TabViewEngineSession
 import java.util.ArrayList
 
 internal class TabsSessionModel(
@@ -153,25 +148,5 @@ internal class TabsSessionModel(
             this.monitoringSession?.unregister(this)
             this.monitoringSession = null
         }
-
-        // empty
-        override fun onShowFileChooser(
-            es: TabViewEngineSession,
-            filePathCallback: ValueCallback<Array<Uri>>?,
-            fileChooserParams: WebChromeClient.FileChooserParams?
-        ): Boolean = false
-
-        // empty
-        override fun updateFailingUrl(url: String?, updateFromError: Boolean) = Unit
-
-        // empty
-        override fun handleExternalUrl(url: String?): Boolean = false
-
-        // empty
-        override fun onHttpAuthRequest(
-            callback: TabViewClient.HttpAuthCallback,
-            host: String?,
-            realm: String?
-        ) = Unit
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
+++ b/app/src/main/java/org/mozilla/focus/utils/AppConfigWrapper.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.mozilla.rocket.appupdate.InAppUpdateConfig;
 import org.mozilla.rocket.appupdate.InAppUpdateIntro;
 import org.mozilla.rocket.chrome.BottomBarItemAdapter;
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType;
 import org.mozilla.rocket.chrome.MenuItemAdapter;
 
 import java.util.ArrayList;
@@ -110,7 +111,8 @@ public class AppConfigWrapper {
             for (int i = 0; i < jsonArray.length(); i++) {
                 JSONObject row = jsonArray.getJSONObject(i);
                 int type = row.getInt("type");
-                itemDataList.add(new BottomBarItemAdapter.ItemData(type));
+                ItemType itemType = ItemType.values()[type];
+                itemDataList.add(new BottomBarItemAdapter.ItemData(itemType));
             }
         } catch (JSONException e) {
             e.printStackTrace();
@@ -146,7 +148,8 @@ public class AppConfigWrapper {
             for (int i = 0; i < jsonArray.length(); i++) {
                 JSONObject row = jsonArray.getJSONObject(i);
                 int type = row.getInt("type");
-                itemDataList.add(new BottomBarItemAdapter.ItemData(type));
+                ItemType itemType = ItemType.values()[type];
+                itemDataList.add(new BottomBarItemAdapter.ItemData(itemType));
             }
         } catch (JSONException e) {
             e.printStackTrace();
@@ -164,7 +167,8 @@ public class AppConfigWrapper {
             for (int i = 0; i < jsonArray.length(); i++) {
                 JSONObject row = jsonArray.getJSONObject(i);
                 int type = row.getInt("type");
-                itemDataList.add(new BottomBarItemAdapter.ItemData(type));
+                ItemType itemType = ItemType.values()[type];
+                itemDataList.add(new BottomBarItemAdapter.ItemData(itemType));
             }
         } catch (JSONException e) {
             e.printStackTrace();

--- a/app/src/main/java/org/mozilla/rocket/browser/BottomBarController.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BottomBarController.kt
@@ -13,6 +13,8 @@ import org.mozilla.focus.databinding.FragmentBrowserBinding
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.Settings
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.DownloadState
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType
 import org.mozilla.rocket.chrome.BottomBarItemAdapter.Theme
 import org.mozilla.rocket.chrome.BottomBarViewModel
 import org.mozilla.rocket.chrome.ChromeViewModel
@@ -82,8 +84,8 @@ class BottomBarController(private val fragment: BrowserFragment) : LifecycleObse
             sendTelemetryForBottomBarClick(type, position)
         }
 
-        browserBottomBar.setOnItemLongClickListener { type: Int, _: Int ->
-            if (type == BottomBarItemAdapter.TYPE_MENU) {
+        browserBottomBar.setOnItemLongClickListener { type: ItemType, _: Int ->
+            if (type == ItemType.MENU) {
                 // Long press menu always show download panel
                 chromeViewModel.showDownloadPanel.call()
                 TelemetryWrapper.longPressDownloadIndicator()
@@ -133,14 +135,14 @@ class BottomBarController(private val fragment: BrowserFragment) : LifecycleObse
             .switchFrom(bottomBarViewModel.items)
             .observeOnViewLifecycle { status: DownloadIndicatorViewModel.Status ->
                 val downloadState = when (status) {
-                    IndicatorStatus.DOWNLOADING -> BottomBarItemAdapter.DOWNLOAD_STATE_DOWNLOADING
-                    IndicatorStatus.UNREAD -> BottomBarItemAdapter.DOWNLOAD_STATE_UNREAD
-                    IndicatorStatus.WARNING -> BottomBarItemAdapter.DOWNLOAD_STATE_WARNING
-                    IndicatorStatus.DEFAULT -> BottomBarItemAdapter.DOWNLOAD_STATE_DEFAULT
+                    IndicatorStatus.DOWNLOADING -> DownloadState.DOWNLOADING
+                    IndicatorStatus.UNREAD -> DownloadState.UNREAD
+                    IndicatorStatus.WARNING -> DownloadState.WARNING
+                    IndicatorStatus.DEFAULT -> DownloadState.DEFAULT
                 }
                 bottomBarItemAdapter?.setDownloadState(downloadState)
 
-                if (status == DownloadIndicatorViewModel.Status.DEFAULT) {
+                if (downloadState == DownloadState.DEFAULT) {
                     return@observeOnViewLifecycle
                 }
 
@@ -151,7 +153,7 @@ class BottomBarController(private val fragment: BrowserFragment) : LifecycleObse
                 }
 
                 eventHistory.add(Settings.Event.ShowDownloadIndicatorIntro)
-                val menuView = bottomBarItemAdapter?.getItem(BottomBarItemAdapter.TYPE_MENU)?.view
+                val menuView = bottomBarItemAdapter?.getItem(ItemType.MENU)?.view
                     ?: return@observeOnViewLifecycle
 
                 initDownloadIndicatorIntroView(fragment, menuView, binding.root) { introView ->
@@ -160,54 +162,54 @@ class BottomBarController(private val fragment: BrowserFragment) : LifecycleObse
             }
     }
 
-    private fun updateChromeViewModelForBottomBarClick(type: Int, position: Int) = when (type) {
-        BottomBarItemAdapter.TYPE_TAB_COUNTER -> chromeViewModel.showTabTray.call()
-        BottomBarItemAdapter.TYPE_MENU -> chromeViewModel.showBrowserMenu.call()
-        BottomBarItemAdapter.TYPE_HOME -> chromeViewModel.showNewTab.call()
-        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = fragment.chromeUrl
-        BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
-        BottomBarItemAdapter.TYPE_BOOKMARK -> chromeViewModel.toggleBookmark()
-        BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
-        BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
-        BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
-        BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
+    private fun updateChromeViewModelForBottomBarClick(t: ItemType, position: Int) = when (t) {
+        ItemType.TAB_COUNTER -> chromeViewModel.showTabTray.call()
+        ItemType.MENU -> chromeViewModel.showBrowserMenu.call()
+        ItemType.HOME -> chromeViewModel.showNewTab.call()
+        ItemType.SEARCH -> chromeViewModel.showUrlInput.value = fragment.chromeUrl
+        ItemType.PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
+        ItemType.BOOKMARK -> chromeViewModel.toggleBookmark()
+        ItemType.REFRESH -> chromeViewModel.refreshOrStop.call()
+        ItemType.SHARE -> chromeViewModel.share.call()
+        ItemType.NEXT -> chromeViewModel.goNext.call()
+        ItemType.CAPTURE -> chromeViewModel.onDoScreenshot(
             ChromeViewModel.ScreenCaptureTelemetryData(
                 TelemetryWrapper.Extra_Value.WEBVIEW,
                 position
             )
         )
-        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $t")
     }
 
-    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) {
+    private fun sendTelemetryForBottomBarClick(type: ItemType, position: Int) {
         when (type) {
-            BottomBarItemAdapter.TYPE_TAB_COUNTER ->
+            ItemType.TAB_COUNTER ->
                 TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_MENU ->
+            ItemType.MENU ->
                 TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_HOME ->
+            ItemType.HOME ->
                 TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_SEARCH ->
+            ItemType.SEARCH ->
                 TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
+            ItemType.PIN_SHORTCUT ->
                 TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_REFRESH ->
+            ItemType.REFRESH ->
                 TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_SHARE ->
+            ItemType.SHARE ->
                 TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_NEXT ->
+            ItemType.NEXT ->
                 TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_BOOKMARK -> {
+            ItemType.BOOKMARK -> {
                 val isActivated = isBookmarkItemActivated()
                 TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
             }
-            BottomBarItemAdapter.TYPE_CAPTURE -> Unit
+            ItemType.CAPTURE -> Unit
             else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
         }
     }
 
     private fun isBookmarkItemActivated(): Boolean {
-        val bookmarkItem = bottomBarItemAdapter?.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
+        val bookmarkItem = bottomBarItemAdapter?.getItem(ItemType.BOOKMARK)
         return bookmarkItem?.view?.isActivated == true
     }
 

--- a/app/src/main/java/org/mozilla/rocket/browser/BottomBarController.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BottomBarController.kt
@@ -1,0 +1,227 @@
+package org.mozilla.rocket.browser
+
+import android.content.res.Configuration
+import android.view.View
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import androidx.lifecycle.OnLifecycleEvent
+import dagger.Lazy
+import org.mozilla.focus.databinding.FragmentBrowserBinding
+import org.mozilla.focus.telemetry.TelemetryWrapper
+import org.mozilla.focus.utils.Settings
+import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.Theme
+import org.mozilla.rocket.chrome.BottomBarViewModel
+import org.mozilla.rocket.chrome.ChromeViewModel
+import org.mozilla.rocket.content.appComponent
+import org.mozilla.rocket.content.getActivityViewModel
+import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.initDownloadIndicatorIntroView
+import org.mozilla.rocket.download.DownloadIndicatorViewModel
+import org.mozilla.rocket.extension.switchFrom
+import javax.inject.Inject
+import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value.WEBVIEW as EXTRA_WEB_VIEW
+import org.mozilla.rocket.download.DownloadIndicatorViewModel.Status as IndicatorStatus
+
+class BottomBarController(private val fragment: BrowserFragment) : LifecycleObserver {
+
+    @Inject
+    lateinit var chromeViewModelCreator: Lazy<ChromeViewModel>
+
+    @Inject
+    lateinit var bottomBarViewModelCreator: Lazy<BottomBarViewModel>
+
+    @Inject
+    lateinit var indicatorViewModelCreator: Lazy<DownloadIndicatorViewModel>
+
+    private lateinit var chromeViewModel: ChromeViewModel
+    private lateinit var bottomBarViewModel: BottomBarViewModel
+    private lateinit var downloadIndicatorViewModel: DownloadIndicatorViewModel
+
+    private var bottomBarItemAdapter: BottomBarItemAdapter? = null
+    private var downloadIndicatorIntro: View? = null
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun onViewCreated() {
+        fragment.appComponent().inject(this)
+        downloadIndicatorViewModel = fragment.getActivityViewModel(indicatorViewModelCreator)
+        bottomBarViewModel = fragment.getActivityViewModel(bottomBarViewModelCreator)
+        chromeViewModel = fragment.getActivityViewModel(chromeViewModelCreator)
+
+        val binding = fragment.binding ?: return
+        setupBottomBar(binding)
+        setupDownloadIndicator(binding)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun onDestroyView() {
+        bottomBarItemAdapter = null
+    }
+
+    fun screenRotateToLandscape(isLandscape: Boolean) {
+        bottomBarViewModel.onScreenRotatedToLandscape(isLandscape)
+    }
+
+    fun refreshViewModel() {
+        bottomBarViewModel.refresh()
+    }
+
+    fun dismissDownloadIndicatorIntroView() {
+        downloadIndicatorIntro?.visibility = View.GONE
+        downloadIndicatorIntro = null
+    }
+
+    private fun setupBottomBar(binding: FragmentBrowserBinding) {
+        val browserBottomBar = binding.browserBottomBar
+        bottomBarItemAdapter = BottomBarItemAdapter(browserBottomBar, Theme.Light)
+
+        browserBottomBar.setOnItemClickListener { type, position ->
+            updateChromeViewModelForBottomBarClick(type, position)
+            sendTelemetryForBottomBarClick(type, position)
+        }
+
+        browserBottomBar.setOnItemLongClickListener { type: Int, _: Int ->
+            if (type == BottomBarItemAdapter.TYPE_MENU) {
+                // Long press menu always show download panel
+                chromeViewModel.showDownloadPanel.call()
+                TelemetryWrapper.longPressDownloadIndicator()
+                true
+            } else {
+                false
+            }
+        }
+
+        // if items in ViewModel changed, update adapter
+        bottomBarViewModel.items.observeOnViewLifecycle { items ->
+            bottomBarItemAdapter?.setItems(items)
+        }
+
+        // This equals to of using switchMap. LiveData of tabCount will be RECREATED
+        // via calling `map`, once `bottomBarViewModel.items` is updated.
+        // bottomBarViewModel.items.switchMap { chromeViewModel.tabCount.map { it } }
+        //     .observeOnViewLifecycle { count: Int -> ... }
+        // Namely, `setTabCount` will be called whenever bottomBarViewModel.items are changed
+        // regardless chromeViewModel.tabCount.value is changed or not.
+        chromeViewModel.tabCount.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { count: Int ->
+                bottomBarItemAdapter?.setTabCount(count, true)
+            }
+        chromeViewModel.isDarkTheme.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { isDarkTheme ->
+                bottomBarItemAdapter?.setDarkTheme(isDarkTheme)
+            }
+        chromeViewModel.isRefreshing.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { isRefreshing: Boolean ->
+                bottomBarItemAdapter?.setRefreshing(isRefreshing)
+                fragment.updateLoadingState(isRefreshing)
+            }
+        chromeViewModel.canGoForward.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { canGoForward: Boolean ->
+                bottomBarItemAdapter?.setCanGoForward(canGoForward)
+            }
+        chromeViewModel.isCurrentUrlBookmarked.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { isBookmark: Boolean ->
+                bottomBarItemAdapter?.setBookmark(isBookmark)
+            }
+    }
+
+    private fun setupDownloadIndicator(binding: FragmentBrowserBinding) {
+        downloadIndicatorViewModel
+            .downloadIndicatorObservable
+            .switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { status: DownloadIndicatorViewModel.Status ->
+                val downloadState = when (status) {
+                    IndicatorStatus.DOWNLOADING -> BottomBarItemAdapter.DOWNLOAD_STATE_DOWNLOADING
+                    IndicatorStatus.UNREAD -> BottomBarItemAdapter.DOWNLOAD_STATE_UNREAD
+                    IndicatorStatus.WARNING -> BottomBarItemAdapter.DOWNLOAD_STATE_WARNING
+                    IndicatorStatus.DEFAULT -> BottomBarItemAdapter.DOWNLOAD_STATE_DEFAULT
+                }
+                bottomBarItemAdapter?.setDownloadState(downloadState)
+
+                if (status == DownloadIndicatorViewModel.Status.DEFAULT) {
+                    return@observeOnViewLifecycle
+                }
+
+                val eventHistory = Settings.getInstance(fragment.activity).eventHistory
+                // if Intro has showed before, return
+                if (eventHistory.contains(Settings.Event.ShowDownloadIndicatorIntro)) {
+                    return@observeOnViewLifecycle
+                }
+
+                eventHistory.add(Settings.Event.ShowDownloadIndicatorIntro)
+                val menuView = bottomBarItemAdapter?.getItem(BottomBarItemAdapter.TYPE_MENU)?.view
+                    ?: return@observeOnViewLifecycle
+
+                initDownloadIndicatorIntroView(fragment, menuView, binding.root) { introView ->
+                    downloadIndicatorIntro = introView
+                }
+            }
+    }
+
+    private fun updateChromeViewModelForBottomBarClick(type: Int, position: Int) = when (type) {
+        BottomBarItemAdapter.TYPE_TAB_COUNTER -> chromeViewModel.showTabTray.call()
+        BottomBarItemAdapter.TYPE_MENU -> chromeViewModel.showBrowserMenu.call()
+        BottomBarItemAdapter.TYPE_HOME -> chromeViewModel.showNewTab.call()
+        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = fragment.chromeUrl
+        BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
+        BottomBarItemAdapter.TYPE_BOOKMARK -> chromeViewModel.toggleBookmark()
+        BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
+        BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
+        BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
+        BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
+            ChromeViewModel.ScreenCaptureTelemetryData(
+                TelemetryWrapper.Extra_Value.WEBVIEW,
+                position
+            )
+        )
+        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+    }
+
+    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) {
+        when (type) {
+            BottomBarItemAdapter.TYPE_TAB_COUNTER ->
+                TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_MENU ->
+                TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_HOME ->
+                TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_SEARCH ->
+                TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
+                TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_REFRESH ->
+                TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_SHARE ->
+                TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_NEXT ->
+                TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_BOOKMARK -> {
+                val isActivated = isBookmarkItemActivated()
+                TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
+            }
+            BottomBarItemAdapter.TYPE_CAPTURE -> Unit
+            else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+        }
+    }
+
+    private fun isBookmarkItemActivated(): Boolean {
+        val bookmarkItem = bottomBarItemAdapter?.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
+        return bookmarkItem?.view?.isActivated == true
+    }
+
+    private fun isInLandscape(): Boolean {
+        return fragment.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+    }
+
+    /**
+     * A helper function to observer a LiveData via View's lifecycle
+     */
+    private fun <X> LiveData<X>.observeOnViewLifecycle(
+        lifecycleOwner: LifecycleOwner = fragment.viewLifecycleOwner,
+        observer: Observer<X>
+    ) {
+        this.observe(lifecycleOwner, observer)
+    }
+}

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -115,11 +115,11 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
 
     private var tabTransitionAnimator: ValueAnimator? = null
 
-    // getUrl() is used for things like sharing the current URL. We could try to use the webview,
-    // but sometimes it's null, and sometimes it returns a null URL. Sometimes it returns a data:
-    // URL for error pages. The URL we show in the toolbar is (A) always correct and (B) what the
-    // user is probably expecting to share, so lets use that here:
-    val url: String
+    // This is used for things like sharing the current Url. We could try to access Url of WebView,
+    // but sometimes itself is null, and sometimes it returns a null Url. Sometimes it returns a
+    // Url with `data:` scheme for error pages. The Url we show in the toolbar should be 1) always
+    // correct and 2) a Url that user is probably expecting to share, so lets use that here:
+    val chromeUrl: String
         get() = binding?.toolbar?.displayUrl?.text?.toString().orEmpty()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -350,7 +350,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         BottomBarItemAdapter.TYPE_TAB_COUNTER -> chromeViewModel.showTabTray.call()
         BottomBarItemAdapter.TYPE_MENU -> chromeViewModel.showBrowserMenu.call()
         BottomBarItemAdapter.TYPE_HOME -> chromeViewModel.showNewTab.call()
-        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = url
+        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = chromeUrl
         BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
         BottomBarItemAdapter.TYPE_BOOKMARK -> chromeViewModel.toggleBookmark()
         BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
@@ -562,7 +562,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         if (activity == null || download == null) {
             return
         }
-        chromeViewModel.onEnqueueDownload(download, url)
+        chromeViewModel.onEnqueueDownload(download, chromeUrl)
     }
 
     fun enterFullScreen(callback: FullscreenCallback, view: View) {
@@ -724,7 +724,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
 
     private fun initialiseNormalBrowserUi() {
         binding?.toolbar?.displayUrl?.setOnClickListener {
-            chromeViewModel.showUrlInput.value = url
+            chromeViewModel.showUrlInput.value = chromeUrl
             // TODO: Needs to confirm with bi that what vertical should be passed into in normal browser using cases
             // TODO: For now just pass a empty string
             TelemetryWrapper.clickUrlbar("", isInLandscape())

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -4,6 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.rocket.browser
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
 import android.app.Dialog
 import android.content.res.Configuration
 import android.graphics.drawable.TransitionDrawable
@@ -25,10 +28,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.Snackbar
 import dagger.Lazy
 import org.mozilla.focus.R
 import org.mozilla.focus.databinding.FragmentBrowserBinding
 import org.mozilla.focus.locale.LocaleAwareFragment
+import org.mozilla.focus.menu.WebContextMenu
 import org.mozilla.focus.navigation.ScreenNavigator
 import org.mozilla.focus.navigation.ScreenNavigator.BrowserScreen
 import org.mozilla.focus.tabs.tabtray.TabTray
@@ -37,7 +42,6 @@ import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.utils.ViewUtils
-import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.focus.widget.FindInPage
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
 import org.mozilla.rocket.chrome.BottomBarItemAdapter.Theme
@@ -51,23 +55,25 @@ import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.OnViewInflat
 import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.initDownloadIndicatorIntroView
 import org.mozilla.rocket.download.DownloadIndicatorViewModel
 import org.mozilla.rocket.download.DownloadIndicatorViewModel.Status
+import org.mozilla.rocket.extension.UrlStringExtension.removeUrlFragment
 import org.mozilla.rocket.extension.switchFrom
-import org.mozilla.rocket.extension.thenRun
 import org.mozilla.rocket.shopping.search.ShoppingSearchController
+import org.mozilla.rocket.tabs.Session
 import org.mozilla.rocket.tabs.SessionManager
+import org.mozilla.rocket.tabs.TabView
 import org.mozilla.rocket.tabs.TabView.FullscreenCallback
-import org.mozilla.rocket.tabs.TabsSessionProvider
-import org.mozilla.rocket.tabs.utils.TabUtil
 import org.mozilla.rocket.tabs.web.Download
-import org.mozilla.threadutils.ThreadUtils
+import org.mozilla.rocket.tabs.web.DownloadCallback
 import org.mozilla.urlutils.UrlUtils
+import java.lang.ref.WeakReference
 import javax.inject.Inject
+import mozilla.components.browser.session.Session.FindResult as MozillaFindResult
 import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value.WEBVIEW as EXTRA_WEB_VIEW
 
 /**
  * Fragment for displaying the browser UI.
  */
-class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable {
+class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
 
     @Inject
     lateinit var downloadIndicatorViewModelCreator: Lazy<DownloadIndicatorViewModel>
@@ -82,34 +88,32 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     lateinit var bottomBarViewModel: BottomBarViewModel
     private lateinit var bottomBarItemAdapter: BottomBarItemAdapter
 
-    var binding: FragmentBrowserBinding? = null
+    private var binding: FragmentBrowserBinding? = null
 
-    var systemVisibility = ViewUtils.SYSTEM_UI_VISIBILITY_NONE
-    var isLoading = false
+    private var systemVisibility = ViewUtils.SYSTEM_UI_VISIBILITY_NONE
+    private var isLoading = false
 
-    lateinit var sessionManager: SessionManager
-    private val sessionObserver = SessionObserver(this)
-    private val managerObserver = SessionManagerObserver(this, sessionObserver)
+    private lateinit var findInPage: FindInPage
 
-    lateinit var findInPage: FindInPage
-
-    lateinit var appBarBgTransition: TransitionDrawable
-    lateinit var statusBarBgTransition: TransitionDrawable
-
-    var webContextMenu: Dialog? = null
+    private lateinit var appBarBgTransition: TransitionDrawable
+    private lateinit var statusBarBgTransition: TransitionDrawable
 
     var loadedUrl: String? = null
 
-    var fullscreenCallback: FullscreenCallback? = null
+    private var fullscreenCallback: FullscreenCallback? = null
 
+    private var webContextMenu: WeakReference<Dialog>? = null
     private var downloadIndicatorIntro: View? = null
     private var landscapeStartTime = 0L
 
+    private val sessionCtrl = SessionController(this)
     private val geolocationController = GeolocationPermissionController(this)
     private val captureCtrl = CaptureController(this)
     private val shoppingSearchCtrl = ShoppingSearchController(this)
     private val fileChooseController = FileChooseController(this)
     private val downloadCtrl = DownloadController(this)
+
+    private var tabTransitionAnimator: ValueAnimator? = null
 
     // getUrl() is used for things like sharing the current URL. We could try to use the webview,
     // but sometimes it's null, and sometimes it returns a null URL. Sometimes it returns a data:
@@ -118,15 +122,12 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     val url: String
         get() = binding?.toolbar?.displayUrl?.text?.toString().orEmpty()
 
-    val isPopupWindowAllowed: Boolean
-        get() = ScreenNavigator[context].isBrowserInForeground &&
-            isAdded && !TabTray.isShowing(parentFragmentManager)
-
     override fun onCreate(savedInstanceState: Bundle?) {
         this.appComponent().inject(this)
         super.onCreate(savedInstanceState)
         bottomBarViewModel = getActivityViewModel(bottomBarViewModelCreator)
         chromeViewModel = getActivityViewModel(chromeViewModelCreator)
+        lifecycle.addObserver(sessionCtrl)
         lifecycle.addObserver(captureCtrl)
         lifecycle.addObserver(geolocationController)
         lifecycle.addObserver(shoppingSearchCtrl)
@@ -142,16 +143,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         this.binding = it
     }.root
 
-    override fun onResume() {
-        sessionManager.resume()
-        super.onResume()
-    }
-
-    override fun onPause() {
-        sessionManager.pause()
-        super.onPause()
-    }
-
     override fun applyLocale() {
         // We create and destroy a new WebView here to force the internal state of WebView to know
         // about the new language. See issue #666.
@@ -159,7 +150,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         unneeded.destroy()
     }
 
-    fun updateURL(url: String?) {
+    fun updateChromeUrl(url: String?) {
         if (UrlUtils.isInternalErrorURL(url)) {
             return
         }
@@ -209,6 +200,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         chromeViewModel.isRefreshing.switchFrom(bottomBarViewModel.items)
             .observeOnViewLifecycle { isRefreshing: Boolean ->
                 bottomBarItemAdapter.setRefreshing(isRefreshing)
+                updateLoadingState(isRefreshing)
             }
         chromeViewModel.canGoForward.switchFrom(bottomBarViewModel.items)
             .observeOnViewLifecycle { canGoForward: Boolean ->
@@ -219,6 +211,19 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
                 bottomBarItemAdapter.setBookmark(isBookmark)
             }
         setupDownloadIndicator()
+    }
+
+    private fun updateLoadingState(isLoading: Boolean) {
+        this.isLoading = isLoading
+
+        if (isLoading) {
+            loadedUrl = null
+            appBarBgTransition.resetTransition()
+            statusBarBgTransition.resetTransition()
+        } else {
+            appBarBgTransition.startTransition(ANIMATION_DURATION)
+            statusBarBgTransition.startTransition(ANIMATION_DURATION)
+        }
     }
 
     private fun setupDownloadIndicator() {
@@ -276,25 +281,10 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         setupBottomBar()
         findInPage = FindInPage(container)
         initialiseNormalBrowserUi()
-        sessionManager = TabsSessionProvider.getOrThrow(activity)
-        sessionManager.register(managerObserver, this, false)
         shoppingSearchCtrl.onViewCreated(binding.shoppingSearchStub)
 
         // maybe Fragment was destroyed
-        maybeRestoreWebViewState(savedInstanceState)
-    }
-
-    private fun maybeRestoreWebViewState(savedInstanceState: Bundle?) {
-        val savedState = savedInstanceState ?: return
-        // FIXME: Obviously, only restore current tab is not enough
-        val focusTab = sessionManager.focusSession ?: return
-        val tabView = focusTab.engineSession?.tabView
-        if (tabView != null) {
-            tabView.restoreViewState(savedState)
-        } else {
-            // Focus to tab again to force initialization.
-            sessionManager.switchToTab(focusTab.id)
-        }
+        sessionCtrl.maybeRestoreWebViewState(savedInstanceState)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -320,23 +310,28 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     }
 
     private fun observeChromeAction() {
-        chromeViewModel.isTurboModeEnabled.observeOnViewLifecycle { setContentBlockingEnabled(it) }
-        chromeViewModel.isBlockImageEnabled.observeOnViewLifecycle { setImageBlockingEnabled(it) }
+        chromeViewModel.isTurboModeEnabled.observeOnViewLifecycle {
+            sessionCtrl.setContentBlockingEnabled(it)
+        }
+        chromeViewModel.isBlockImageEnabled.observeOnViewLifecycle {
+            sessionCtrl.setImageBlockingEnabled(it)
+        }
+        chromeViewModel.isCurrentSessionSecure.observeOnViewLifecycle { updateSiteIdentity(it) }
         chromeViewModel.doScreenshot.observeOnViewLifecycle { startCapture(it) }
         chromeViewModel.isDarkTheme.observeOnViewLifecycle { setDarkThemeEnabled(it) }
-        chromeViewModel.goNext.observeOnViewLifecycle { canGoForward().thenRun { goForward() } }
-        chromeViewModel.goBack.observeOnViewLifecycle { canGoBack().thenRun { goBack() } }
+        chromeViewModel.goNext.observeOnViewLifecycle { sessionCtrl.maybeGoForward() }
+        chromeViewModel.goBack.observeOnViewLifecycle { sessionCtrl.maybeGoBack() }
 
         chromeViewModel.refreshOrStop.observeOnViewLifecycle {
             if (isLoading) {
-                stop()
+                sessionCtrl.stop()
             } else {
-                reload()
+                sessionCtrl.reload()
             }
         }
 
         chromeViewModel.isBlockJavaScriptEnabled.observeOnViewLifecycle {
-            setJavaScriptBlockingEnabled(it)
+            sessionCtrl.setJavaScriptBlockingEnabled(it)
         }
 
         chromeViewModel.showFindInPage.observeOnViewLifecycle {
@@ -400,11 +395,11 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     }
 
     private fun startCapture(params: Parcelable?) {
-        val currentTab = sessionManager.focusSession ?: return
+        val currentTab = sessionCtrl.getFocusSession() ?: return
         val currentWebView = currentTab.engineSession?.tabView as? WebView ?: return
         captureCtrl.capture(currentWebView, params as? ScreenCaptureTelemetryData) {
             // My shot on boarding didn't show before and capture is succeed, skip to show toast
-            checkToShowMyShotOnBoarding()
+            chromeViewModel.checkToShowMyShotOnBoarding()
         }
     }
 
@@ -430,7 +425,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     }
 
     override fun goBackground() {
-        val current = sessionManager.focusSession ?: return
+        val current = sessionCtrl.getFocusSession() ?: return
         val es = current.engineSession ?: return
         es.detach()
         val tabView = es.tabView ?: return
@@ -438,7 +433,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
     }
 
     override fun goForeground() {
-        val current = sessionManager.focusSession ?: return
+        val current = sessionCtrl.getFocusSession() ?: return
         val tabView = current.engineSession?.tabView ?: return
         val webViewSlot = binding?.webviewSlot ?: return
 
@@ -447,73 +442,20 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         }
     }
 
-    private fun initialiseNormalBrowserUi() {
-        binding?.toolbar?.displayUrl?.setOnClickListener {
-            chromeViewModel.showUrlInput.value = url
-            // TODO: Needs to confirm with bi that what vertical should be passed into in normal browser using cases
-            // TODO: For now just pass a empty string
-            TelemetryWrapper.clickUrlbar("", isInLandscape())
-        }
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
-        sessionManager.focusSession?.engineSession?.tabView?.saveViewState(outState)
-
-        // Workaround for #1107 TransactionTooLargeException
-        // since Android N, system throws a exception rather than just a warning(then drop bundle)
-        // To set a threshold for dropping WebView state manually
-        // refer: https://issuetracker.google.com/issues/37103380
-        val key = "WEBVIEW_CHROMIUM_STATE"
-        if (outState.containsKey(key)) {
-            val size = outState.getByteArray(key)?.size ?: -1
-            if (size > BUNDLE_MAX_SIZE) {
-                outState.remove(key)
-            }
-        }
+        sessionCtrl.saveViewStateFromFocusedSession(outState)
         super.onSaveInstanceState(outState)
     }
 
     override fun onStop() {
-        if (systemVisibility != ViewUtils.SYSTEM_UI_VISIBILITY_NONE) {
-            sessionManager.focusSession?.engineSession?.tabView?.performExitFullScreen()
-        }
         geolocationController.dismissGeolocationDialog()
         super.onStop()
     }
 
     override fun onDestroyView() {
-        sessionManager.unregister(managerObserver)
         shoppingSearchCtrl.onDestroyView()
         binding = null
         super.onDestroyView()
-    }
-
-    private fun setContentBlockingEnabled(enabled: Boolean) {
-        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
-        // for configuring blocking function of each tab.
-        for (session in sessionManager.getTabs()) {
-            session.engineSession?.tabView?.setContentBlockingEnabled(enabled)
-        }
-    }
-
-    private fun setImageBlockingEnabled(enabled: Boolean) {
-        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
-        // for configuring blocking function of each tab.
-        for (session in sessionManager.getTabs()) {
-            session.engineSession?.tabView?.setImageBlockingEnabled(enabled)
-        }
-    }
-
-    private fun setJavaScriptBlockingEnabled(enabled: Boolean) {
-        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
-        // for configuring JavaScript blocking function of each tab.
-        for (session in sessionManager.getTabs()) {
-            session.engineSession?.tabView?.setJavaScriptBlockingEnabled(enabled)
-        }
-    }
-
-    fun updateIsLoading(isLoading: Boolean) {
-        this.isLoading = isLoading
     }
 
     override fun onBackPressed(): Boolean {
@@ -525,21 +467,10 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         // it may not be able to get 'onExitFullScreen' callback from WebChromeClient. Just call it here
         // to leave the full screen mode.
         if (binding?.videoContainer?.visibility == View.VISIBLE) {
-            sessionObserver.onExitFullScreen()
+            sessionCtrl.chromeExitFullScreen()
             return true
         }
-        if (canGoBack()) {
-            // Go back in web history
-            goBack()
-        } else {
-            val focus = sessionManager.focusSession ?: return false
-            if (focus.isFromExternal || focus.hasParentTab()) {
-                sessionManager.closeTab(focus.id)
-            } else {
-                ScreenNavigator[context].popToHomeScreen(true)
-            }
-        }
-        return true
+        return sessionCtrl.handleBackKey()
     }
 
     /**
@@ -554,80 +485,47 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         isFromExternal: Boolean,
         onViewReadyCallback: Runnable?
     ) {
-        loadedUrl = url
-        if (SupportUtils.isUrl(url)) {
-            if (openNewTab) {
-                sessionManager.addTab(url, TabUtil.argument(null, isFromExternal, true))
-                // Per spec, if download indicator intro view is showed when new tabb is opened, just dismiss it anyway.
-                dismissDownloadIndicatorIntroView()
-                // In case we call SessionManager#addTab(), which is an async operation calls back in the next
-                // message loop. By posting this runnable we can call back in the same message loop with
-                // TabsContentListener#onFocusChanged(), which is when the view is ready and being attached.
-                ThreadUtils.postToMainThread(onViewReadyCallback)
-            } else {
-                val currentTab = sessionManager.focusSession
-                if (currentTab?.engineSession?.tabView != null) {
-                    currentTab.engineSession?.tabView?.loadUrl(url)
-                    onViewReadyCallback?.run()
-                } else {
-                    sessionManager.addTab(url, TabUtil.argument(null, isFromExternal, true))
-                    ThreadUtils.postToMainThread(onViewReadyCallback)
-                }
+        if (!SupportUtils.isUrl(url)) {
+            if (AppConstants.isDevBuild()) {
+                // throw exception to highlight this issue, except release build.
+                throw RuntimeException("trying to open an invalid url: $url")
             }
-        } else if (AppConstants.isDevBuild()) {
-            // throw exception to highlight this issue, except release build.
-            throw RuntimeException("trying to open a invalid url: $url")
+
+            return
         }
+
+        if (openNewTab) {
+            // Per spec, if download indicator intro view is showed when new tabb is opened
+            // just dismiss it anyway.
+            dismissDownloadIndicatorIntroView()
+        }
+
+        loadedUrl = url
+        sessionCtrl.loadUrl(url, openNewTab, isFromExternal, onViewReadyCallback)
     }
 
     override fun switchToTab(tabId: String) {
-        if (!TextUtils.isEmpty(tabId)) {
-            sessionManager.switchToTab(tabId)
-        }
+        sessionCtrl.switchToTab(tabId)
     }
 
     override fun getFragment(): Fragment {
         return this
     }
 
-    fun canGoForward(): Boolean = sessionManager.focusSession?.canGoForward == true
+    fun refreshChrome(focusSession: Session) {
+        geolocationController.dismissGeolocationDialog()
+        updateChromeUrl(focusSession.url)
 
-    fun canGoBack(): Boolean = sessionManager.focusSession?.canGoBack == true
-
-    private fun goBack() {
-        val currentTab = sessionManager.focusSession
-        if (currentTab != null) {
-            val current = currentTab.engineSession?.tabView
-            // The Session.canGoBack property is mainly for UI display purpose and is only sampled
-            // at onNavigationStateChange which is called at onPageFinished, onPageStarted and
-            // onReceivedTitle. We do some sanity check here.
-            if (current == null || !current.canGoBack()) {
-                return
-            }
-            current.goBack()
-            if ((current as WebView).originalUrl != null) {
-                loadedUrl = (current as WebView).originalUrl
-            }
+        if (focusSession.progress == 0 || focusSession.progress == 100) {
+            binding?.progressBar?.visibility = View.GONE
+        } else {
+            binding?.progressBar?.progress = focusSession.progress
         }
-    }
 
-    private fun goForward() {
-        val currentTab = sessionManager.focusSession
-        if (currentTab != null) {
-            val current = currentTab.engineSession?.tabView ?: return
-            current.goForward()
-            if ((current as WebView).originalUrl != null) {
-                loadedUrl = (current as WebView).originalUrl
-            }
-        }
-    }
-
-    private fun reload() {
-        sessionManager.focusSession?.engineSession?.tabView?.reload()
-    }
-
-    private fun stop() {
-        sessionManager.focusSession?.engineSession?.tabView?.stopLoading()
+        updateSiteIdentity(focusSession.securityInfo.secure)
+        hideFindInPage()
+        // check if newer config exists whenever navigating to Browser screen
+        bottomBarViewModel.refresh()
     }
 
     fun dismissAllMenus() {
@@ -635,51 +533,15 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         geolocationController.dismissGeolocationDialog()
     }
 
-    private fun dismissWebContextMenu() {
-        webContextMenu?.let {
-            it.dismiss()
-            webContextMenu = null
+    fun maybeShowGeolocationPermission(origin: String, callback: GeolocationPermissions.Callback?) {
+        val isPopupWindowAllowed = isAdded &&
+            ScreenNavigator[context].isBrowserInForeground &&
+            !TabTray.isShowing(parentFragmentManager)
+
+        if (!isPopupWindowAllowed) {
+            return
         }
-    }
-
-    fun getWebViewSlot(): ViewGroup? = binding?.webviewSlot
-
-    private fun showFindInPage() {
-        val binding = this.binding ?: return
-        val focusTab = sessionManager.focusSession ?: return
-
-        binding.root.isActivated = false
-        binding.appBar.setExpanded(false)
-        binding.browserBottomBar.visibility = View.INVISIBLE
-        hidePluggableUi()
-        findInPage.onDismissListener = {
-            binding.root.isActivated = true
-            binding.appBar.setExpanded(true)
-            binding.browserBottomBar.visibility = View.VISIBLE
-            showPluggableUi()
-        }
-        findInPage.show(focusTab)
-        TelemetryWrapper.findInPage(TelemetryWrapper.FIND_IN_PAGE.OPEN_BY_MENU)
-    }
-
-    fun hideFindInPage() {
-        findInPage.hide()
-    }
-
-    fun showPluggableUi() {
-        shoppingSearchCtrl.setVisible()
-    }
-
-    fun hidePluggableUi() {
-        shoppingSearchCtrl.setInvisible()
-    }
-
-    fun showGeolocationPermission(origin: String, callback: GeolocationPermissions.Callback?) {
         geolocationController.showGeolocationDialog(origin, callback)
-    }
-
-    fun closeGeolocationPermission() {
-        geolocationController.dismissGeolocationDialog()
     }
 
     fun chooseFile(
@@ -703,8 +565,183 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         chromeViewModel.onEnqueueDownload(download, url)
     }
 
-    private fun checkToShowMyShotOnBoarding() {
-        chromeViewModel.checkToShowMyShotOnBoarding()
+    fun enterFullScreen(callback: FullscreenCallback, view: View) {
+        fullscreenCallback = callback
+        val binding = binding ?: return
+        // Hide browser UI and web content
+        binding.appBar.visibility = View.INVISIBLE
+        binding.webviewContainer.visibility = View.INVISIBLE
+        binding.browserBottomBar.visibility = View.INVISIBLE
+
+        // Add view to video container and make it visible
+        val params = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+        )
+        binding.videoContainer.addView(view, params)
+        binding.videoContainer.visibility = View.VISIBLE
+
+        hidePluggableUi()
+
+        // Switch to immersive mode: Hide system bars other UI controls
+        systemVisibility = ViewUtils.switchToImmersiveMode(activity)
+    }
+
+    fun exitFullScreen() {
+        val binding = binding ?: return
+        // Remove custom video views and hide container
+        binding.videoContainer.removeAllViews()
+        binding.videoContainer.visibility = View.GONE
+
+        // Show browser UI and web content again
+        binding.appBar.visibility = View.VISIBLE
+        binding.webviewContainer.visibility = View.VISIBLE
+        binding.browserBottomBar.visibility = View.VISIBLE
+        if (systemVisibility != ViewUtils.SYSTEM_UI_VISIBILITY_NONE) {
+            // TODO: check, should we reset systemVisibility after exiting immersive mode?
+            ViewUtils.exitImmersiveMode(systemVisibility, activity)
+        }
+        showPluggableUi()
+
+        // Notify renderer that we left fullscreen mode.
+        fullscreenCallback?.fullScreenExited()
+        fullscreenCallback = null
+    }
+
+    fun showSnackBarForAddedSession(clickAction: View.OnClickListener) {
+        val binding = binding ?: return
+        val snackBar = Snackbar.make(
+            binding.root, R.string.new_background_tab_hint,
+            Snackbar.LENGTH_LONG
+        )
+        snackBar.setAction(R.string.new_background_tab_switch, clickAction)
+        snackBar.show()
+    }
+
+    private fun updateSiteIdentity(isSecure: Boolean) {
+        val level = if (isSecure) SITE_LOCK else SITE_GLOBE
+        binding?.toolbar?.siteIdentity?.setImageLevel(level)
+    }
+
+    fun updateProgressOfSession(session: Session, progress: Int) {
+        hideFindInPage()
+        // Remove URL fragment to prevent progress bar update when location.hash change
+        // (follow Chrome and Firefox for Android behavior)
+        val baseSessionUrl = session.url?.removeUrlFragment()
+        val baseLoadedUrl = loadedUrl?.removeUrlFragment()
+        val progressIsForLoadedUrl = TextUtils.equals(baseSessionUrl, baseLoadedUrl)
+
+        // Some new url may give 100 directly and then start from 0 again. don't treat
+        // as loaded for these urls;
+        val progressBar = binding?.progressBar
+        val sessionIsFinishingLoading = if (progressBar == null) {
+            false
+        } else {
+            val progressBarWasNotFull = progressBar.max != progressBar.progress
+            val progressBarIsNowFull = progress == progressBar.max
+            progressBarWasNotFull && progressBarIsNowFull
+        }
+        if (sessionIsFinishingLoading) {
+            loadedUrl = session.url
+        }
+        // Some URL cause progress bar to stuck at loading state,
+        // allowing progress update to progressBar.max solve the issue
+        if (progressIsForLoadedUrl && progress != progressBar?.max) {
+            return
+        }
+        progressBar?.progress = progress
+    }
+
+    fun showContextMenu(hitTarget: TabView.HitTarget) {
+        val activity = activity ?: return
+        val dialog = WebContextMenu.show(
+            false,
+            activity,
+            BrowserDownloadCallback(this),
+            hitTarget
+        )
+        webContextMenu = WeakReference(dialog)
+    }
+
+    fun getSnackBarAnchor(): View? {
+        return binding?.browserBottomBar
+    }
+
+    fun isSystemUiChanged(): Boolean {
+        return systemVisibility != ViewUtils.SYSTEM_UI_VISIBILITY_NONE
+    }
+
+    fun setReceivedFindResult(result: MozillaFindResult) {
+        findInPage.onFindResultReceived(result)
+    }
+
+    fun transitToTab(inView: View?) {
+        val webViewSlot = binding?.webviewSlot ?: return
+
+        val outView = webViewSlot.findExistingTabView()
+        webViewSlot.removeView(outView)
+        webViewSlot.addView(inView)
+
+        if (inView != null) {
+            startTransitionAnimation(null, inView)
+        }
+    }
+
+    private fun startTransitionAnimation(outView: View?, inView: View) {
+        stopTabTransition()
+        inView.alpha = 0f
+        outView?.alpha = 1f
+
+        tabTransitionAnimator = createTransitionAnimator(inView, outView)
+        tabTransitionAnimator?.start()
+    }
+
+    private fun createTransitionAnimator(inView: View, outView: View?): ValueAnimator {
+        val duration = resources.getInteger(R.integer.tab_transition_time).toLong()
+        val animator = ValueAnimator.ofFloat(0f, 1f).setDuration(duration)
+        animator.addUpdateListener { animation ->
+            val alpha = animation.animatedValue as Float
+            inView.alpha = alpha
+            outView?.alpha = 1 - alpha
+        }
+        animator.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator) {
+                inView.alpha = 1f
+                outView?.alpha = 1f
+                tabTransitionAnimator = null
+            }
+        })
+
+        return animator
+    }
+
+    private fun stopTabTransition() {
+        val animator = tabTransitionAnimator ?: return
+        if (animator.isRunning) {
+            animator.end()
+        }
+        tabTransitionAnimator = null
+    }
+
+    private fun initialiseNormalBrowserUi() {
+        binding?.toolbar?.displayUrl?.setOnClickListener {
+            chromeViewModel.showUrlInput.value = url
+            // TODO: Needs to confirm with bi that what vertical should be passed into in normal browser using cases
+            // TODO: For now just pass a empty string
+            TelemetryWrapper.clickUrlbar("", isInLandscape())
+        }
+    }
+
+    private fun dismissWebContextMenu() {
+        webContextMenu?.get()?.dismiss()
+        webContextMenu = null
+    }
+
+    private fun showPluggableUi() {
+        shoppingSearchCtrl.setVisible()
+    }
+
+    private fun hidePluggableUi() {
+        shoppingSearchCtrl.setInvisible()
     }
 
     private fun setDarkThemeEnabled(enable: Boolean) {
@@ -722,32 +759,69 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
 
     private fun dismissDownloadIndicatorIntroView() {
         downloadIndicatorIntro?.visibility = View.GONE
+        downloadIndicatorIntro = null
     }
 
-    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) = when (type) {
-        BottomBarItemAdapter.TYPE_TAB_COUNTER ->
-            TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-        BottomBarItemAdapter.TYPE_MENU ->
-            TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
-        BottomBarItemAdapter.TYPE_HOME ->
-            TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-        BottomBarItemAdapter.TYPE_SEARCH ->
-            TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
-        BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
-            TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
-        BottomBarItemAdapter.TYPE_REFRESH ->
-            TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
-        BottomBarItemAdapter.TYPE_SHARE ->
-            TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
-        BottomBarItemAdapter.TYPE_NEXT ->
-            TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
-        BottomBarItemAdapter.TYPE_BOOKMARK -> {
-            val bookmarkItem = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
-            val isActivated = bookmarkItem?.view?.isActivated == true
-            TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
+    private fun showFindInPage() {
+        val binding = this.binding ?: return
+        val focusTab = sessionCtrl.getFocusSession() ?: return
+
+        binding.root.isActivated = false
+        binding.appBar.setExpanded(false)
+        binding.browserBottomBar.visibility = View.INVISIBLE
+        hidePluggableUi()
+        findInPage.onDismissListener = {
+            binding.root.isActivated = true
+            binding.appBar.setExpanded(true)
+            binding.browserBottomBar.visibility = View.VISIBLE
+            showPluggableUi()
         }
-        BottomBarItemAdapter.TYPE_CAPTURE -> Unit
-        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+        findInPage.show(focusTab)
+        TelemetryWrapper.findInPage(TelemetryWrapper.FIND_IN_PAGE.OPEN_BY_MENU)
+    }
+
+    private fun hideFindInPage() {
+        findInPage.hide()
+    }
+
+    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) {
+        when (type) {
+            BottomBarItemAdapter.TYPE_TAB_COUNTER ->
+                TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_MENU ->
+                TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_HOME ->
+                TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_SEARCH ->
+                TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
+                TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_REFRESH ->
+                TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_SHARE ->
+                TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
+            BottomBarItemAdapter.TYPE_NEXT ->
+                TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
+            BottomBarItemAdapter.TYPE_BOOKMARK -> {
+                val bookmarkItem = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
+                val isActivated = bookmarkItem?.view?.isActivated == true
+                TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
+            }
+            BottomBarItemAdapter.TYPE_CAPTURE -> Unit
+            else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+        }
+    }
+
+    private fun ViewGroup?.findExistingTabView(): View? {
+        val parent = this ?: return null
+        val viewCount = parent.childCount
+        for (childIdx in 0 until viewCount) {
+            val childView = parent.getChildAt(childIdx)
+            if (childView is TabView) {
+                return (childView as TabView).getView()
+            }
+        }
+        return null
     }
 
     /**
@@ -760,6 +834,14 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         this.observe(lifecycleOwner, observer)
     }
 
+    private class BrowserDownloadCallback(
+        private val fragment: BrowserFragment
+    ) : DownloadCallback {
+        override fun onDownloadStart(download: Download) {
+            fragment.maybeQueueDownload(download)
+        }
+    }
+
     companion object {
         /**
          * Custom data that is passed when calling [SessionManager.addTab]
@@ -770,6 +852,5 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         const val ANIMATION_DURATION = 300
         const val SITE_GLOBE = 0
         const val SITE_LOCK = 1
-        const val BUNDLE_MAX_SIZE = 300 * 1000 // 300K
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -53,6 +53,7 @@ import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.initDownload
 import org.mozilla.rocket.download.DownloadIndicatorViewModel
 import org.mozilla.rocket.download.DownloadIndicatorViewModel.Status
 import org.mozilla.rocket.extension.switchFrom
+import org.mozilla.rocket.extension.thenRun
 import org.mozilla.rocket.shopping.search.ShoppingSearchController
 import org.mozilla.rocket.tabs.SessionManager
 import org.mozilla.rocket.tabs.TabView.FullscreenCallback
@@ -164,55 +165,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         }
         binding?.toolbar?.displayUrl?.text = UrlUtils.stripUserInfo(url)
         shoppingSearchCtrl.notifyUrlChanged()
-    }
-
-    private fun observeChromeAction() {
-        chromeViewModel.isTurboModeEnabled.observeOnViewLifecycle { enabled: Boolean ->
-            setContentBlockingEnabled(enabled)
-        }
-        chromeViewModel.isBlockImageEnabled.observeOnViewLifecycle { enabled: Boolean ->
-            setImageBlockingEnabled(enabled)
-        }
-        chromeViewModel.isBlockJavaScriptEnabled.observeOnViewLifecycle { enabled: Boolean ->
-            setJavaScriptBlockingEnabled(enabled)
-        }
-        chromeViewModel.doScreenshot.observeOnViewLifecycle { telemetryData ->
-            startCapture(telemetryData)
-        }
-
-        chromeViewModel.refreshOrStop.observeOnViewLifecycle {
-            if (isLoading) {
-                stop()
-            } else {
-                reload()
-            }
-        }
-
-        chromeViewModel.goNext.observeOnViewLifecycle {
-            if (canGoForward()) {
-                goForward()
-            }
-        }
-
-        chromeViewModel.goBack.observeOnViewLifecycle {
-            if (canGoBack()) {
-                goBack()
-            }
-        }
-
-        chromeViewModel.showFindInPage.observeOnViewLifecycle {
-            if (chromeViewModel.navigationState.value?.isBrowser == true) {
-                showFindInPage()
-            }
-        }
-        chromeViewModel.currentUrl.observeOnViewLifecycle {
-            binding?.appBar?.setExpanded(true)
-            binding?.browserBottomBar?.slideUp()
-        }
-    }
-
-    private fun observeDarkTheme() {
-        chromeViewModel.isDarkTheme.observeOnViewLifecycle { setDarkThemeEnabled(it) }
     }
 
     private fun setupBottomBar() {
@@ -327,10 +279,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         setupDownloadIndicator()
     }
 
-    private fun isInLandscape(): Boolean {
-        return resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-    }
-
     private fun setupDownloadIndicator() {
         val downloadIndicatorViewModel = getActivityViewModel(downloadIndicatorViewModelCreator)
         downloadIndicatorViewModel
@@ -389,7 +337,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         sessionManager = TabsSessionProvider.getOrThrow(activity)
         sessionManager.register(managerObserver, this, false)
         shoppingSearchCtrl.onViewCreated(binding.shoppingSearchStub)
-        observeDarkTheme()
 
         // maybe Fragment was destroyed
         maybeRestoreWebViewState(savedInstanceState)
@@ -428,6 +375,42 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
             height = bottomBarHeight
         }
         browserBottomBar.onScreenRotated()
+    }
+
+    private fun observeChromeAction() {
+        chromeViewModel.isTurboModeEnabled.observeOnViewLifecycle { setContentBlockingEnabled(it) }
+        chromeViewModel.isBlockImageEnabled.observeOnViewLifecycle { setImageBlockingEnabled(it) }
+        chromeViewModel.doScreenshot.observeOnViewLifecycle { startCapture(it) }
+        chromeViewModel.isDarkTheme.observeOnViewLifecycle { setDarkThemeEnabled(it) }
+        chromeViewModel.goNext.observeOnViewLifecycle { canGoForward().thenRun { goForward() } }
+        chromeViewModel.goBack.observeOnViewLifecycle { canGoBack().thenRun { goBack() } }
+
+        chromeViewModel.refreshOrStop.observeOnViewLifecycle {
+            if (isLoading) {
+                stop()
+            } else {
+                reload()
+            }
+        }
+
+        chromeViewModel.isBlockJavaScriptEnabled.observeOnViewLifecycle {
+            setJavaScriptBlockingEnabled(it)
+        }
+
+        chromeViewModel.showFindInPage.observeOnViewLifecycle {
+            if (chromeViewModel.navigationState.value?.isBrowser == true) {
+                showFindInPage()
+            }
+        }
+
+        chromeViewModel.currentUrl.observeOnViewLifecycle {
+            binding?.appBar?.setExpanded(true)
+            binding?.browserBottomBar?.slideUp()
+        }
+    }
+
+    private fun isInLandscape(): Boolean {
+        return resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     }
 
     // Workaround for full-screen WebView issue that the video doesn't fit the viewport
@@ -547,7 +530,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         super.onDestroyView()
     }
 
-    fun setContentBlockingEnabled(enabled: Boolean) {
+    private fun setContentBlockingEnabled(enabled: Boolean) {
         // TODO: Better if we can move this logic to some setting-like classes, and provider interface
         // for configuring blocking function of each tab.
         for (session in sessionManager.getTabs()) {
@@ -555,7 +538,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
         }
     }
 
-    fun setImageBlockingEnabled(enabled: Boolean) {
+    private fun setImageBlockingEnabled(enabled: Boolean) {
         // TODO: Better if we can move this logic to some setting-like classes, and provider interface
         // for configuring blocking function of each tab.
         for (session in sessionManager.getTabs()) {

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -51,7 +51,6 @@ import org.mozilla.rocket.chrome.ChromeViewModel.ScreenCaptureTelemetryData
 import org.mozilla.rocket.content.appComponent
 import org.mozilla.rocket.content.getActivityViewModel
 import org.mozilla.rocket.content.view.BottomBar.BottomBarBehavior.Companion.slideUp
-import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.OnViewInflated
 import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.initDownloadIndicatorIntroView
 import org.mozilla.rocket.download.DownloadIndicatorViewModel
 import org.mozilla.rocket.download.DownloadIndicatorViewModel.Status
@@ -240,23 +239,22 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
                 }
                 bottomBarItemAdapter.setDownloadState(downloadState)
 
+                if (status == Status.DEFAULT) {
+                    return@observeOnViewLifecycle
+                }
+
                 val eventHistory = Settings.getInstance(activity).eventHistory
-                if (!eventHistory.contains(Settings.Event.ShowDownloadIndicatorIntro) && status !== Status.DEFAULT) {
-                    eventHistory.add(Settings.Event.ShowDownloadIndicatorIntro)
-                    val menuItem = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_MENU)
-                    val rootView = binding?.root
-                    if (rootView != null && menuItem?.view != null) {
-                        initDownloadIndicatorIntroView(
-                            this,
-                            menuItem.view,
-                            rootView,
-                            object : OnViewInflated {
-                                override fun onInflated(view: View) {
-                                    downloadIndicatorIntro = view
-                                }
-                            }
-                        )
-                    }
+                // if Intro has showed before, return
+                if (eventHistory.contains(Settings.Event.ShowDownloadIndicatorIntro)) {
+                    return@observeOnViewLifecycle
+                }
+
+                eventHistory.add(Settings.Event.ShowDownloadIndicatorIntro)
+                val rootView = binding?.root ?: return@observeOnViewLifecycle
+                val menuView = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_MENU)?.view
+                    ?: return@observeOnViewLifecycle
+                initDownloadIndicatorIntroView(this, menuView, rootView) {
+                    downloadIndicatorIntro = it
                 }
             }
     }

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -33,8 +33,6 @@ import org.mozilla.focus.navigation.ScreenNavigator
 import org.mozilla.focus.navigation.ScreenNavigator.BrowserScreen
 import org.mozilla.focus.tabs.tabtray.TabTray
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value
-import org.mozilla.focus.telemetry.TelemetryWrapper.longPressDownloadIndicator
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
@@ -42,6 +40,7 @@ import org.mozilla.focus.utils.ViewUtils
 import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.focus.widget.FindInPage
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.Theme
 import org.mozilla.rocket.chrome.BottomBarViewModel
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.chrome.ChromeViewModel.ScreenCaptureTelemetryData
@@ -63,6 +62,7 @@ import org.mozilla.rocket.tabs.web.Download
 import org.mozilla.threadutils.ThreadUtils
 import org.mozilla.urlutils.UrlUtils
 import javax.inject.Inject
+import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value.WEBVIEW as EXTRA_WEB_VIEW
 
 /**
  * Fragment for displaying the browser UI.
@@ -169,100 +169,42 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
 
     private fun setupBottomBar() {
         val browserBottomBar = binding?.browserBottomBar ?: return
+        bottomBarItemAdapter = BottomBarItemAdapter(browserBottomBar, Theme.Light)
+
         browserBottomBar.setOnItemClickListener { type, position ->
-            when (type) {
-                BottomBarItemAdapter.TYPE_TAB_COUNTER -> {
-                    chromeViewModel.showTabTray.call()
-                    TelemetryWrapper.showTabTrayToolbar(
-                        Extra_Value.WEBVIEW,
-                        position,
-                        isInLandscape()
-                    )
-                }
-                BottomBarItemAdapter.TYPE_MENU -> {
-                    chromeViewModel.showBrowserMenu.call()
-                    TelemetryWrapper.showMenuToolbar(Extra_Value.WEBVIEW, position)
-                }
-                BottomBarItemAdapter.TYPE_HOME -> {
-                    chromeViewModel.showNewTab.call()
-                    TelemetryWrapper.clickAddTabToolbar(
-                        Extra_Value.WEBVIEW,
-                        position,
-                        isInLandscape()
-                    )
-                }
-                BottomBarItemAdapter.TYPE_SEARCH -> {
-                    chromeViewModel.showUrlInput.value = url
-                    TelemetryWrapper.clickToolbarSearch(
-                        Extra_Value.WEBVIEW,
-                        position,
-                        isInLandscape()
-                    )
-                }
-                BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
-                    ScreenCaptureTelemetryData(Extra_Value.WEBVIEW, position)
-                )
-                BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> {
-                    chromeViewModel.pinShortcut.call()
-                    TelemetryWrapper.clickAddToHome(Extra_Value.WEBVIEW, position)
-                }
-                BottomBarItemAdapter.TYPE_BOOKMARK -> {
-                    val isActivated =
-                        bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)?.view?.isActivated == true
-                    TelemetryWrapper.clickToolbarBookmark(
-                        !isActivated,
-                        Extra_Value.WEBVIEW,
-                        position
-                    )
-                    chromeViewModel.toggleBookmark()
-                }
-                BottomBarItemAdapter.TYPE_REFRESH -> {
-                    chromeViewModel.refreshOrStop.call()
-                    TelemetryWrapper.clickToolbarReload(
-                        Extra_Value.WEBVIEW,
-                        position,
-                        isInLandscape()
-                    )
-                }
-                BottomBarItemAdapter.TYPE_SHARE -> {
-                    chromeViewModel.share.call()
-                    TelemetryWrapper.clickToolbarShare(
-                        Extra_Value.WEBVIEW,
-                        position,
-                        isInLandscape()
-                    )
-                }
-                BottomBarItemAdapter.TYPE_NEXT -> {
-                    chromeViewModel.goNext.call()
-                    TelemetryWrapper.clickToolbarForward(Extra_Value.WEBVIEW, position)
-                }
-                else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
-            }
+            updateChromeViewModelForBottomBarClick(type, position)
+            sendTelemetryForBottomBarClick(type, position)
         }
+
         browserBottomBar.setOnItemLongClickListener { type: Int, _: Int ->
             if (type == BottomBarItemAdapter.TYPE_MENU) {
                 // Long press menu always show download panel
                 chromeViewModel.showDownloadPanel.call()
-                longPressDownloadIndicator()
+                TelemetryWrapper.longPressDownloadIndicator()
                 true
             } else {
                 false
             }
         }
-        bottomBarItemAdapter =
-            BottomBarItemAdapter(browserBottomBar, BottomBarItemAdapter.Theme.Light)
-        bottomBarViewModel.items.observeOnViewLifecycle { types ->
-            bottomBarItemAdapter.setItems(types)
+
+        // if items in ViewModel changed, update adapter
+        bottomBarViewModel.items.observeOnViewLifecycle { items ->
+            bottomBarItemAdapter.setItems(items)
         }
 
-        chromeViewModel.isDarkTheme.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { isDarkTheme ->
-                bottomBarItemAdapter.setDarkTheme(isDarkTheme)
-            }
-
+        // This equals to of using switchMap. LiveData of tabCount will be RECREATED
+        // via calling `map`, once `bottomBarViewModel.items` is updated.
+        // bottomBarViewModel.items.switchMap { chromeViewModel.tabCount.map { it } }
+        //     .observeOnViewLifecycle { count: Int -> ... }
+        // Namely, `setTabCount` will be called whenever bottomBarViewModel.items are changed
+        // regardless chromeViewModel.tabCount.value is changed or not.
         chromeViewModel.tabCount.switchFrom(bottomBarViewModel.items)
             .observeOnViewLifecycle { count: Int ->
                 bottomBarItemAdapter.setTabCount(count, true)
+            }
+        chromeViewModel.isDarkTheme.switchFrom(bottomBarViewModel.items)
+            .observeOnViewLifecycle { isDarkTheme ->
+                bottomBarItemAdapter.setDarkTheme(isDarkTheme)
             }
         chromeViewModel.isRefreshing.switchFrom(bottomBarViewModel.items)
             .observeOnViewLifecycle { isRefreshing: Boolean ->
@@ -407,6 +349,22 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
             binding?.appBar?.setExpanded(true)
             binding?.browserBottomBar?.slideUp()
         }
+    }
+
+    private fun updateChromeViewModelForBottomBarClick(type: Int, position: Int) = when (type) {
+        BottomBarItemAdapter.TYPE_TAB_COUNTER -> chromeViewModel.showTabTray.call()
+        BottomBarItemAdapter.TYPE_MENU -> chromeViewModel.showBrowserMenu.call()
+        BottomBarItemAdapter.TYPE_HOME -> chromeViewModel.showNewTab.call()
+        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = url
+        BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
+        BottomBarItemAdapter.TYPE_BOOKMARK -> chromeViewModel.toggleBookmark()
+        BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
+        BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
+        BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
+        BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
+            ScreenCaptureTelemetryData(EXTRA_WEB_VIEW, position)
+        )
+        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
     }
 
     private fun isInLandscape(): Boolean {
@@ -764,6 +722,32 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen, BackKeyHandleable 
 
     private fun dismissDownloadIndicatorIntroView() {
         downloadIndicatorIntro?.visibility = View.GONE
+    }
+
+    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) = when (type) {
+        BottomBarItemAdapter.TYPE_TAB_COUNTER ->
+            TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+        BottomBarItemAdapter.TYPE_MENU ->
+            TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
+        BottomBarItemAdapter.TYPE_HOME ->
+            TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
+        BottomBarItemAdapter.TYPE_SEARCH ->
+            TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
+        BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
+            TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
+        BottomBarItemAdapter.TYPE_REFRESH ->
+            TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
+        BottomBarItemAdapter.TYPE_SHARE ->
+            TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
+        BottomBarItemAdapter.TYPE_NEXT ->
+            TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
+        BottomBarItemAdapter.TYPE_BOOKMARK -> {
+            val bookmarkItem = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
+            val isActivated = bookmarkItem?.view?.isActivated == true
+            TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
+        }
+        BottomBarItemAdapter.TYPE_CAPTURE -> Unit
+        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
     }
 
     /**

--- a/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/BrowserFragment.kt
@@ -39,23 +39,15 @@ import org.mozilla.focus.navigation.ScreenNavigator.BrowserScreen
 import org.mozilla.focus.tabs.tabtray.TabTray
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.AppConstants
-import org.mozilla.focus.utils.Settings
 import org.mozilla.focus.utils.SupportUtils
 import org.mozilla.focus.utils.ViewUtils
 import org.mozilla.focus.widget.FindInPage
-import org.mozilla.rocket.chrome.BottomBarItemAdapter
-import org.mozilla.rocket.chrome.BottomBarItemAdapter.Theme
-import org.mozilla.rocket.chrome.BottomBarViewModel
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.chrome.ChromeViewModel.ScreenCaptureTelemetryData
 import org.mozilla.rocket.content.appComponent
 import org.mozilla.rocket.content.getActivityViewModel
 import org.mozilla.rocket.content.view.BottomBar.BottomBarBehavior.Companion.slideUp
-import org.mozilla.rocket.download.DownloadIndicatorIntroViewHelper.initDownloadIndicatorIntroView
-import org.mozilla.rocket.download.DownloadIndicatorViewModel
-import org.mozilla.rocket.download.DownloadIndicatorViewModel.Status
 import org.mozilla.rocket.extension.UrlStringExtension.removeUrlFragment
-import org.mozilla.rocket.extension.switchFrom
 import org.mozilla.rocket.shopping.search.ShoppingSearchController
 import org.mozilla.rocket.tabs.Session
 import org.mozilla.rocket.tabs.SessionManager
@@ -67,7 +59,6 @@ import org.mozilla.urlutils.UrlUtils
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 import mozilla.components.browser.session.Session.FindResult as MozillaFindResult
-import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value.WEBVIEW as EXTRA_WEB_VIEW
 
 /**
  * Fragment for displaying the browser UI.
@@ -75,19 +66,11 @@ import org.mozilla.focus.telemetry.TelemetryWrapper.Extra_Value.WEBVIEW as EXTRA
 class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
 
     @Inject
-    lateinit var downloadIndicatorViewModelCreator: Lazy<DownloadIndicatorViewModel>
-
-    @Inject
-    lateinit var bottomBarViewModelCreator: Lazy<BottomBarViewModel>
-
-    @Inject
     lateinit var chromeViewModelCreator: Lazy<ChromeViewModel>
 
     lateinit var chromeViewModel: ChromeViewModel
-    lateinit var bottomBarViewModel: BottomBarViewModel
-    private lateinit var bottomBarItemAdapter: BottomBarItemAdapter
 
-    private var binding: FragmentBrowserBinding? = null
+    var binding: FragmentBrowserBinding? = null
 
     private var systemVisibility = ViewUtils.SYSTEM_UI_VISIBILITY_NONE
     private var isLoading = false
@@ -102,10 +85,11 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
     private var fullscreenCallback: FullscreenCallback? = null
 
     private var webContextMenu: WeakReference<Dialog>? = null
-    private var downloadIndicatorIntro: View? = null
     private var landscapeStartTime = 0L
 
     private val sessionCtrl = SessionController(this)
+    private val bottomBarCtrl = BottomBarController(this)
+
     private val geolocationController = GeolocationPermissionController(this)
     private val captureCtrl = CaptureController(this)
     private val shoppingSearchCtrl = ShoppingSearchController(this)
@@ -124,7 +108,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
     override fun onCreate(savedInstanceState: Bundle?) {
         this.appComponent().inject(this)
         super.onCreate(savedInstanceState)
-        bottomBarViewModel = getActivityViewModel(bottomBarViewModelCreator)
         chromeViewModel = getActivityViewModel(chromeViewModelCreator)
         lifecycle.addObserver(sessionCtrl)
         lifecycle.addObserver(captureCtrl)
@@ -157,62 +140,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         shoppingSearchCtrl.notifyUrlChanged()
     }
 
-    private fun setupBottomBar() {
-        val browserBottomBar = binding?.browserBottomBar ?: return
-        bottomBarItemAdapter = BottomBarItemAdapter(browserBottomBar, Theme.Light)
-
-        browserBottomBar.setOnItemClickListener { type, position ->
-            updateChromeViewModelForBottomBarClick(type, position)
-            sendTelemetryForBottomBarClick(type, position)
-        }
-
-        browserBottomBar.setOnItemLongClickListener { type: Int, _: Int ->
-            if (type == BottomBarItemAdapter.TYPE_MENU) {
-                // Long press menu always show download panel
-                chromeViewModel.showDownloadPanel.call()
-                TelemetryWrapper.longPressDownloadIndicator()
-                true
-            } else {
-                false
-            }
-        }
-
-        // if items in ViewModel changed, update adapter
-        bottomBarViewModel.items.observeOnViewLifecycle { items ->
-            bottomBarItemAdapter.setItems(items)
-        }
-
-        // This equals to of using switchMap. LiveData of tabCount will be RECREATED
-        // via calling `map`, once `bottomBarViewModel.items` is updated.
-        // bottomBarViewModel.items.switchMap { chromeViewModel.tabCount.map { it } }
-        //     .observeOnViewLifecycle { count: Int -> ... }
-        // Namely, `setTabCount` will be called whenever bottomBarViewModel.items are changed
-        // regardless chromeViewModel.tabCount.value is changed or not.
-        chromeViewModel.tabCount.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { count: Int ->
-                bottomBarItemAdapter.setTabCount(count, true)
-            }
-        chromeViewModel.isDarkTheme.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { isDarkTheme ->
-                bottomBarItemAdapter.setDarkTheme(isDarkTheme)
-            }
-        chromeViewModel.isRefreshing.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { isRefreshing: Boolean ->
-                bottomBarItemAdapter.setRefreshing(isRefreshing)
-                updateLoadingState(isRefreshing)
-            }
-        chromeViewModel.canGoForward.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { canGoForward: Boolean ->
-                bottomBarItemAdapter.setCanGoForward(canGoForward)
-            }
-        chromeViewModel.isCurrentUrlBookmarked.switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { isBookmark: Boolean ->
-                bottomBarItemAdapter.setBookmark(isBookmark)
-            }
-        setupDownloadIndicator()
-    }
-
-    private fun updateLoadingState(isLoading: Boolean) {
+    fun updateLoadingState(isLoading: Boolean) {
         this.isLoading = isLoading
 
         if (isLoading) {
@@ -225,43 +153,11 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         }
     }
 
-    private fun setupDownloadIndicator() {
-        val downloadIndicatorViewModel = getActivityViewModel(downloadIndicatorViewModelCreator)
-        downloadIndicatorViewModel
-            .downloadIndicatorObservable
-            .switchFrom(bottomBarViewModel.items)
-            .observeOnViewLifecycle { status: Status ->
-                val downloadState = when (status) {
-                    Status.DOWNLOADING -> BottomBarItemAdapter.DOWNLOAD_STATE_DOWNLOADING
-                    Status.UNREAD -> BottomBarItemAdapter.DOWNLOAD_STATE_UNREAD
-                    Status.WARNING -> BottomBarItemAdapter.DOWNLOAD_STATE_WARNING
-                    Status.DEFAULT -> BottomBarItemAdapter.DOWNLOAD_STATE_DEFAULT
-                }
-                bottomBarItemAdapter.setDownloadState(downloadState)
-
-                if (status == Status.DEFAULT) {
-                    return@observeOnViewLifecycle
-                }
-
-                val eventHistory = Settings.getInstance(activity).eventHistory
-                // if Intro has showed before, return
-                if (eventHistory.contains(Settings.Event.ShowDownloadIndicatorIntro)) {
-                    return@observeOnViewLifecycle
-                }
-
-                eventHistory.add(Settings.Event.ShowDownloadIndicatorIntro)
-                val rootView = binding?.root ?: return@observeOnViewLifecycle
-                val menuView = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_MENU)?.view
-                    ?: return@observeOnViewLifecycle
-                initDownloadIndicatorIntroView(this, menuView, rootView) {
-                    downloadIndicatorIntro = it
-                }
-            }
-    }
-
     override fun onViewCreated(container: View, savedInstanceState: Bundle?) {
         super.onViewCreated(container, savedInstanceState)
         val binding = this.binding ?: return
+
+        viewLifecycleOwner.lifecycle.addObserver(bottomBarCtrl)
 
         binding.appBar.setOnApplyWindowInsetsListener { v: View, insets: WindowInsets ->
             (v.layoutParams as MarginLayoutParams).topMargin = insets.systemWindowInsetTop
@@ -276,7 +172,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         appBarBgTransition = binding.urlbar.background as TransitionDrawable
         statusBarBgTransition = binding.insetCover.background as TransitionDrawable
         observeChromeAction()
-        setupBottomBar()
         findInPage = FindInPage(container)
         initialiseNormalBrowserUi()
         shoppingSearchCtrl.onViewCreated(binding.shoppingSearchStub)
@@ -289,10 +184,10 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         super.onConfigurationChanged(newConfig)
         updateBottomBarLayout()
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            bottomBarViewModel.onScreenRotatedToLandscape(true)
+            bottomBarCtrl.screenRotateToLandscape(true)
             onLandscapeModeStart()
         } else {
-            bottomBarViewModel.onScreenRotatedToLandscape(false)
+            bottomBarCtrl.screenRotateToLandscape(false)
             onLandscapeModeFinish()
         }
         refreshVideoContainer()
@@ -342,22 +237,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
             binding?.appBar?.setExpanded(true)
             binding?.browserBottomBar?.slideUp()
         }
-    }
-
-    private fun updateChromeViewModelForBottomBarClick(type: Int, position: Int) = when (type) {
-        BottomBarItemAdapter.TYPE_TAB_COUNTER -> chromeViewModel.showTabTray.call()
-        BottomBarItemAdapter.TYPE_MENU -> chromeViewModel.showBrowserMenu.call()
-        BottomBarItemAdapter.TYPE_HOME -> chromeViewModel.showNewTab.call()
-        BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.value = chromeUrl
-        BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
-        BottomBarItemAdapter.TYPE_BOOKMARK -> chromeViewModel.toggleBookmark()
-        BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
-        BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
-        BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
-        BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
-            ScreenCaptureTelemetryData(EXTRA_WEB_VIEW, position)
-        )
-        else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
     }
 
     private fun isInLandscape(): Boolean {
@@ -495,7 +374,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         if (openNewTab) {
             // Per spec, if download indicator intro view is showed when new tabb is opened
             // just dismiss it anyway.
-            dismissDownloadIndicatorIntroView()
+            bottomBarCtrl.dismissDownloadIndicatorIntroView()
         }
 
         loadedUrl = url
@@ -523,7 +402,7 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         updateSiteIdentity(focusSession.securityInfo.secure)
         hideFindInPage()
         // check if newer config exists whenever navigating to Browser screen
-        bottomBarViewModel.refresh()
+        bottomBarCtrl.refreshViewModel()
     }
 
     fun dismissAllMenus() {
@@ -755,11 +634,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
         ViewUtils.updateStatusBarStyle(!enable, requireActivity().window)
     }
 
-    private fun dismissDownloadIndicatorIntroView() {
-        downloadIndicatorIntro?.visibility = View.GONE
-        downloadIndicatorIntro = null
-    }
-
     private fun showFindInPage() {
         val binding = this.binding ?: return
         val focusTab = sessionCtrl.getFocusSession() ?: return
@@ -780,34 +654,6 @@ class BrowserFragment : LocaleAwareFragment(), BrowserScreen {
 
     private fun hideFindInPage() {
         findInPage.hide()
-    }
-
-    private fun sendTelemetryForBottomBarClick(type: Int, position: Int) {
-        when (type) {
-            BottomBarItemAdapter.TYPE_TAB_COUNTER ->
-                TelemetryWrapper.showTabTrayToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_MENU ->
-                TelemetryWrapper.showMenuToolbar(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_HOME ->
-                TelemetryWrapper.clickAddTabToolbar(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_SEARCH ->
-                TelemetryWrapper.clickToolbarSearch(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_PIN_SHORTCUT ->
-                TelemetryWrapper.clickAddToHome(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_REFRESH ->
-                TelemetryWrapper.clickToolbarReload(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_SHARE ->
-                TelemetryWrapper.clickToolbarShare(EXTRA_WEB_VIEW, position, isInLandscape())
-            BottomBarItemAdapter.TYPE_NEXT ->
-                TelemetryWrapper.clickToolbarForward(EXTRA_WEB_VIEW, position)
-            BottomBarItemAdapter.TYPE_BOOKMARK -> {
-                val bookmarkItem = bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)
-                val isActivated = bookmarkItem?.view?.isActivated == true
-                TelemetryWrapper.clickToolbarBookmark(isActivated, EXTRA_WEB_VIEW, position)
-            }
-            BottomBarItemAdapter.TYPE_CAPTURE -> Unit
-            else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
-        }
     }
 
     private fun ViewGroup?.findExistingTabView(): View? {

--- a/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
@@ -1,0 +1,391 @@
+package org.mozilla.rocket.browser
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.webkit.GeolocationPermissions
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import org.mozilla.focus.navigation.ScreenNavigator
+import org.mozilla.focus.utils.IntentUtils
+import org.mozilla.focus.web.HttpAuthenticationDialogBuilder
+import org.mozilla.rocket.chrome.ChromeViewModel
+import org.mozilla.rocket.extension.thenRun
+import org.mozilla.rocket.tabs.Session
+import org.mozilla.rocket.tabs.SessionManager
+import org.mozilla.rocket.tabs.TabView
+import org.mozilla.rocket.tabs.TabViewClient
+import org.mozilla.rocket.tabs.TabsSessionProvider
+import org.mozilla.rocket.tabs.utils.TabUtil
+import org.mozilla.rocket.tabs.web.Download
+import org.mozilla.threadutils.ThreadUtils
+import mozilla.components.browser.session.Session.FindResult as MozillaFindResult
+
+private const val BUNDLE_MAX_SIZE = 300 * 1000 // 300K
+
+/**
+ * SessionController is a bridge between BrowserFragment and Session's observer.
+ *
+ *   +--------------------+     +-------------------+    +----------------------+
+ *   |  chromeViewModel   |<--->|                   |<-->|SessionManagerObserver|
+ *   +----------^---------+     |                   |    +----------------------+
+ *              |               | SessionController |    +----------------------+
+ *   +----------v---------+     |                   |<-->|   SessionObserver    |
+ *   |  BrowserFragment   |<--->|                   |    |                      |
+ *   +--------------------+     +-------------------+    +----------------------+
+ *
+ * BrowserFragment use SessionController to operate session indirectly. SessionController accepts
+ * changes from Observers, then update BrowserFragment directly, or update ChromeViewModel.
+ *
+ */
+class SessionController(private val browserFragment: BrowserFragment) : LifecycleObserver {
+
+    private lateinit var chromeViewModel: ChromeViewModel
+
+    private lateinit var sessionManager: SessionManager
+    private val sessionObserver = SessionObserver(this)
+    private val managerObserver = SessionManagerObserver(this, isStartedFromExternalApp())
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    fun onCreateFragment() {
+        chromeViewModel = browserFragment.chromeViewModel
+        sessionManager = TabsSessionProvider.getOrThrow(browserFragment.requireActivity())
+        sessionManager.register(managerObserver)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun onDestroyFragment() {
+        sessionManager.unregister(managerObserver)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    fun onResume() {
+        sessionManager.resume()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+    fun onPause() {
+        sessionManager.pause()
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun onStop() {
+        if (browserFragment.isSystemUiChanged()) {
+            chromeExitFullScreen()
+        }
+    }
+
+    fun chromeEnterFullScreen(callback: TabView.FullscreenCallback, view: View) {
+        browserFragment.enterFullScreen(callback, view)
+    }
+
+    fun chromeExitFullScreen() {
+        browserFragment.exitFullScreen()
+        sessionManager.focusSession?.engineSession?.tabView?.performExitFullScreen()
+        sessionObserver.clearFocusFromObservingSession()
+    }
+
+    fun maybeRestoreWebViewState(savedInstanceState: Bundle?) {
+        val savedState = savedInstanceState ?: return
+        // FIXME: Obviously, only restore current tab is not enough
+        val focusTab = sessionManager.focusSession ?: return
+        val tabView = focusTab.engineSession?.tabView
+        if (tabView != null) {
+            tabView.restoreViewState(savedState)
+        } else {
+            // Focus to tab again to force initialization.
+            sessionManager.switchToTab(focusTab.id)
+        }
+    }
+
+    fun saveViewStateFromFocusedSession(outState: Bundle) {
+        sessionManager.focusSession?.engineSession?.tabView?.saveViewState(outState)
+        // Workaround for #1107 TransactionTooLargeException
+        // since Android N, system throws a exception rather than just a warning(then drop bundle)
+        // To set a threshold for dropping WebView state manually
+        // refer: https://issuetracker.google.com/issues/37103380
+        val key = "WEB_VIEW_CHROMIUM_STATE"
+        if (outState.containsKey(key)) {
+            val size = outState.getByteArray(key)?.size ?: -1
+            if (size > BUNDLE_MAX_SIZE) {
+                outState.remove(key)
+            }
+        }
+    }
+
+    fun maybeGoForward() {
+        canGoForward().thenRun { goForward() }
+    }
+
+    fun maybeGoBack() {
+        canGoBack().thenRun { goBack() }
+    }
+
+    fun reload() {
+        sessionManager.focusSession?.engineSession?.tabView?.reload()
+    }
+
+    fun stop() {
+        sessionManager.focusSession?.engineSession?.tabView?.stopLoading()
+    }
+
+    fun getFocusSession(): Session? {
+        return sessionManager.focusSession
+    }
+
+    fun handleBackKey(): Boolean {
+        if (canGoBack()) {
+            // Go back in web history
+            goBack()
+        } else {
+            val focus = sessionManager.focusSession ?: return false
+            if (focus.isFromExternal || focus.hasParentTab()) {
+                sessionManager.closeTab(focus.id)
+            } else {
+                ScreenNavigator[browserFragment.context].popToHomeScreen(true)
+            }
+        }
+        return true
+    }
+
+    fun switchToTab(tabId: String) {
+        if (tabId.isNotBlank()) {
+            sessionManager.switchToTab(tabId)
+        }
+    }
+
+    fun loadUrl(
+        url: String,
+        openNewTab: Boolean,
+        isFromExternal: Boolean,
+        onViewReadyCallback: Runnable?
+    ) {
+        if (openNewTab) {
+            sessionManager.addTab(url, TabUtil.argument(null, isFromExternal, true))
+            // In case we call SessionManager#addTab(), which is an async operation calls back in the next
+            // message loop. By posting this runnable we can call back in the same message loop with
+            // TabsContentListener#onFocusChanged(), which is when the view is ready and being attached.
+            ThreadUtils.postToMainThread(onViewReadyCallback)
+        } else {
+            val currentTab = sessionManager.focusSession?.engineSession?.tabView
+            if (currentTab != null) {
+                currentTab.loadUrl(url)
+                onViewReadyCallback?.run()
+            } else {
+                sessionManager.addTab(url, TabUtil.argument(null, isFromExternal, true))
+                ThreadUtils.postToMainThread(onViewReadyCallback)
+            }
+        }
+    }
+
+    fun setContentBlockingEnabled(enabled: Boolean) {
+        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
+        // for configuring blocking function of each tab.
+        for (session in sessionManager.getTabs()) {
+            session.engineSession?.tabView?.setContentBlockingEnabled(enabled)
+        }
+    }
+
+    fun setImageBlockingEnabled(enabled: Boolean) {
+        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
+        // for configuring blocking function of each tab.
+        for (session in sessionManager.getTabs()) {
+            session.engineSession?.tabView?.setImageBlockingEnabled(enabled)
+        }
+    }
+
+    fun setJavaScriptBlockingEnabled(enabled: Boolean) {
+        // TODO: Better if we can move this logic to some setting-like classes, and provider interface
+        // for configuring JavaScript blocking function of each tab.
+        for (session in sessionManager.getTabs()) {
+            session.engineSession?.tabView?.setJavaScriptBlockingEnabled(enabled)
+        }
+    }
+
+    fun chromePopToHomeScreen() {
+        ScreenNavigator[browserFragment.context].popToHomeScreen(true)
+    }
+
+    fun chromeFinishActivity() {
+        browserFragment.activity?.finish()
+    }
+
+    fun chromeUpdateSiteIdentity(isSecure: Boolean) {
+        chromeViewModel.isCurrentSessionSecure.value = isSecure
+    }
+
+    fun chromeChangeUrlOfFocusedSession(url: String?) {
+        chromeViewModel.onFocusedUrlChanged(url)
+        // Prevent updateURL when directly entering URL in the address bar.
+        val chromeOpenUrl = chromeViewModel.openUrl.value?.url.orEmpty()
+        if (chromeOpenUrl != url) {
+            browserFragment.updateChromeUrl(url)
+        } else if (chromeOpenUrl.isNotEmpty()) {
+            chromeViewModel.openUrl.value!!.url = ""
+        }
+    }
+
+    fun chromeTransitToTab(focusSession: Session) {
+        val tabView = focusSession.engineSession?.tabView?.getView()
+            ?: throw RuntimeException("Tabview should be created at this moment and never be null")
+
+        // ensure the session has not been attached to another parent earlier.
+        focusSession.engineSession?.detach()
+        browserFragment.transitToTab(tabView)
+
+        sessionObserver.changeObservingSession(focusSession)
+
+        chromeViewModel.onFocusedUrlChanged(focusSession.url)
+        chromeViewModel.onFocusedTitleChanged(focusSession.title)
+        browserFragment.refreshChrome(focusSession)
+        chromeViewModel.onNavigationStateChanged(canGoBack(), canGoForward())
+    }
+
+    fun chromePromoteAddedSession(session: Session) {
+        val sessionId = session.id
+        browserFragment.showSnackBarForAddedSession {
+            sessionManager.switchToTab(sessionId)
+        }
+    }
+
+    fun chromeUpdateTabCount(count: Int) {
+        chromeViewModel.onTabCountChanged(count)
+    }
+
+    fun chromeQueueDownload(download: Download): Boolean {
+        val activity = browserFragment.activity ?: return false
+        if (!activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            return false
+        }
+        browserFragment.maybeQueueDownload(download)
+        return true
+    }
+
+    fun chromeHandleExternalUrl(url: String): Boolean {
+        val context = browserFragment.context
+        if (context == null) {
+            val msg = "No context to use, abort callback handleExternalUrl"
+            Log.w(ScreenNavigator.BROWSER_FRAGMENT_TAG, msg)
+            return false
+        }
+        val navigationState = chromeViewModel.navigationState.value
+        if (navigationState != null && navigationState.isHome) {
+            val msg = "Ignore external url when browser page is not on the front"
+            Log.w(ScreenNavigator.BROWSER_FRAGMENT_TAG, msg)
+            return false
+        }
+
+        return IntentUtils.handleExternalUri(context, url)
+    }
+
+    fun chromeChooseFile(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: WebChromeClient.FileChooserParams
+    ) {
+        browserFragment.chooseFile(filePathCallback, fileChooserParams)
+    }
+
+    fun chromeChangeFocusedSessionTitle(title: String?) {
+        chromeViewModel.onFocusedTitleChanged(title)
+    }
+
+    fun chromeShowLinkContextMenu(hitTarget: TabView.HitTarget) {
+        val activity = browserFragment.activity
+        if (activity == null) {
+            val msg = "No context to use, abort callback onLongPress"
+            Log.w(ScreenNavigator.BROWSER_FRAGMENT_TAG, msg)
+            return
+        }
+        browserFragment.showContextMenu(hitTarget)
+    }
+
+    fun chromeShowGeolocationPermission(origin: String, callback: GeolocationPermissions.Callback) {
+        browserFragment.maybeShowGeolocationPermission(origin, callback)
+    }
+
+    fun chromeSetReceivedFindResult(result: MozillaFindResult) {
+        browserFragment.setReceivedFindResult(result)
+    }
+
+    fun chromeChangeNavigationState(canGoBack: Boolean, canGoForward: Boolean) {
+        chromeViewModel.onNavigationStateChanged(canGoBack, canGoForward)
+    }
+
+    fun chromeShowHttpAuth(callback: TabViewClient.HttpAuthCallback, host: String, realm: String) {
+        // TODO: too complicated. should be refactor
+        val activity = browserFragment.activity ?: return
+        val innerBuilder = HttpAuthenticationDialogBuilder.Builder(activity, host, realm)
+        innerBuilder.setOkListener { _: String?, _: String?, username: String?, password: String? ->
+            callback.proceed(username, password)
+        }
+        innerBuilder.setCancelListener { callback.cancel() }
+        val builder = innerBuilder.build()
+        builder.createDialog()
+        builder.show()
+    }
+
+    fun chromeGetUrl(): String = browserFragment.url
+
+    fun chromeUpdateProgress(session: Session, progress: Int) {
+        browserFragment.updateProgressOfSession(session, progress)
+    }
+
+    fun chromeUpdateLoadingState(session: Session, isLoading: Boolean) {
+        if (isLoading) {
+            chromeViewModel.onPageLoadingStarted()
+            browserFragment.updateChromeUrl(session.url)
+        } else {
+            // The URL which is supplied in onTabFinished() could be fake (see #301), but webView's
+            // URL is always correct _except_ for error pages
+            updateUrlFromWebView()
+            chromeViewModel.onPageLoadingStopped()
+        }
+    }
+
+    private fun updateUrlFromWebView() {
+        if (sessionManager.focusSession != null) {
+            val viewURL = sessionManager.focusSession?.url
+            chromeChangeUrlOfFocusedSession(viewURL)
+        }
+    }
+
+    private fun canGoForward(): Boolean = sessionManager.focusSession?.canGoForward == true
+
+    private fun canGoBack(): Boolean = sessionManager.focusSession?.canGoBack == true
+
+    private fun goBack() {
+        val currentTab = sessionManager.focusSession?.engineSession?.tabView ?: return
+        // The Session.canGoBack property is mainly for UI display purpose and is only sampled
+        // at onNavigationStateChange which is called at onPageFinished, onPageStarted and
+        // onReceivedTitle. We do some sanity check here.
+        if (!currentTab.canGoBack()) {
+            return
+        }
+        currentTab.goBack()
+        (currentTab as? WebView)?.originalUrl?.let {
+            browserFragment.loadedUrl = it
+        }
+    }
+
+    private fun goForward() {
+        val currentTab = sessionManager.focusSession?.engineSession?.tabView ?: return
+        currentTab.goForward()
+        (currentTab as? WebView)?.originalUrl?.let {
+            browserFragment.loadedUrl = it
+        }
+    }
+
+    private fun isStartedFromExternalApp(): Boolean {
+        // No SafeIntent needed here because intent.getAction() is safe (SafeIntent simply calls
+        // intent.getAction() without any wrapping):
+        val intent = browserFragment.activity?.intent ?: return false
+        val isInternal = intent.getBooleanExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, false)
+        return !isInternal && Intent.ACTION_VIEW == intent.action
+    }
+}

--- a/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
@@ -330,7 +330,7 @@ class SessionController(private val browserFragment: BrowserFragment) : Lifecycl
         builder.show()
     }
 
-    fun chromeGetUrl(): String = browserFragment.url
+    fun chromeGetUrl(): String = browserFragment.chromeUrl
 
     fun chromeUpdateProgress(session: Session, progress: Int) {
         browserFragment.updateProgressOfSession(session, progress)

--- a/app/src/main/java/org/mozilla/rocket/browser/SessionManagerObserver.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/SessionManagerObserver.kt
@@ -4,200 +4,45 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package org.mozilla.rocket.browser
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
-import android.animation.ValueAnimator
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.view.View
-import android.view.ViewGroup
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
-import com.google.android.material.snackbar.Snackbar
-import org.mozilla.focus.R
-import org.mozilla.focus.navigation.ScreenNavigator
-import org.mozilla.focus.utils.IntentUtils
 import org.mozilla.rocket.tabs.Session
 import org.mozilla.rocket.tabs.SessionManager
 import org.mozilla.rocket.tabs.SessionManager.Factor
-import org.mozilla.rocket.tabs.TabView
-import org.mozilla.rocket.tabs.TabViewClient
-import org.mozilla.rocket.tabs.TabViewEngineSession
 import org.mozilla.rocket.tabs.utils.TabUtil
 
 class SessionManagerObserver(
-    private val browserFragment: BrowserFragment,
-    private val sessionObserver: SessionObserver
+    private val sessionCtrl: SessionController,
+    private val isStartedFromExternalApp: Boolean
 ) : SessionManager.Observer {
 
-    private var tabTransitionAnimator: ValueAnimator? = null
-
     override fun onFocusChanged(session: Session?, factor: Factor) {
-        browserFragment.chromeViewModel.onFocusedUrlChanged(session?.url)
-        browserFragment.chromeViewModel.onFocusedTitleChanged(session?.title)
         if (session == null) {
-            if (factor === Factor.FACTOR_NO_FOCUS && !isStartedFromExternalApp()) {
-                ScreenNavigator.get(browserFragment.context).popToHomeScreen(true)
+            if (factor === Factor.FACTOR_NO_FOCUS && !isStartedFromExternalApp) {
+                sessionCtrl.chromePopToHomeScreen()
             } else {
-                browserFragment.requireActivity().finish()
+                sessionCtrl.chromeFinishActivity()
             }
         } else {
-            transitToTab(session)
-            refreshChrome(session)
+            sessionCtrl.chromeTransitToTab(session)
         }
     }
 
     override fun onSessionAdded(session: Session, arguments: Bundle?) {
-        if (arguments == null) {
-            return
-        }
-        when (arguments.getInt(BrowserFragment.EXTRA_NEW_TAB_SRC, -1)) {
-            BrowserFragment.SRC_CONTEXT_MENU -> onTabAddedByContextMenu(session, arguments)
-            else -> Unit
+        val extra = arguments?.getInt(BrowserFragment.EXTRA_NEW_TAB_SRC, -1)
+        if (extra == BrowserFragment.SRC_CONTEXT_MENU) {
+            promoteAddedSession(session, arguments)
         }
     }
 
     override fun onSessionCountChanged(count: Int) {
-        browserFragment.chromeViewModel.onTabCountChanged(count)
+        sessionCtrl.chromeUpdateTabCount(count)
     }
 
-    private fun transitToTab(targetTab: Session) {
-        val tabView = targetTab.engineSession?.tabView
-            ?: throw RuntimeException("Tabview should be created at this moment and never be null")
-        val webViewSlot = browserFragment.getWebViewSlot()
-            ?: throw RuntimeException("WebViewSlot not found")
-        // ensure it does not have attach to parent earlier.
-        targetTab.engineSession?.detach()
-        val outView = findExistingTabView(browserFragment.getWebViewSlot())
-        webViewSlot.removeView(outView)
-        val inView = tabView.getView()
-        webViewSlot.addView(inView)
-        this.sessionObserver.changeSession(targetTab)
-        if (inView != null) {
-            startTransitionAnimation(null, inView, null)
+    private fun promoteAddedSession(session: Session, arguments: Bundle) {
+        val isFocusingTab = TabUtil.toFocus(arguments)
+        if (isFocusingTab) {
+            return
         }
-    }
-
-    private fun refreshChrome(tab: Session) {
-        browserFragment.closeGeolocationPermission()
-        browserFragment.updateURL(tab.url)
-
-        if (tab.progress == 0 || tab.progress == 100) {
-            browserFragment.binding?.progressBar?.visibility = View.GONE
-        } else {
-            browserFragment.binding?.progressBar?.progress = tab.progress
-        }
-
-        val identity = if (tab.securityInfo.secure) BrowserFragment.SITE_LOCK
-        else BrowserFragment.SITE_GLOBE
-
-        browserFragment.binding?.toolbar?.siteIdentity?.setImageLevel(identity)
-        browserFragment.hideFindInPage()
-        val current = browserFragment.sessionManager.focusSession
-        if (current != null) {
-            browserFragment.chromeViewModel.onNavigationStateChanged(
-                browserFragment.canGoBack(),
-                browserFragment.canGoForward()
-            )
-        }
-        // check if newer config exists whenever navigating to Browser screen
-        browserFragment.bottomBarViewModel.refresh()
-    }
-
-    private fun startTransitionAnimation(
-        outView: View?,
-        inView: View,
-        finishCallback: Runnable?
-    ) {
-        stopTabTransition()
-        inView.alpha = 0f
-        outView?.alpha = 1f
-
-        val duration = inView.resources.getInteger(R.integer.tab_transition_time).toLong()
-        tabTransitionAnimator =
-            ValueAnimator.ofFloat(0f, 1f).setDuration(duration).apply {
-                addUpdateListener { animation ->
-                    val alpha = animation.animatedValue as Float
-                    inView.alpha = alpha
-                    outView?.alpha = 1 - alpha
-                }
-                addListener(object : AnimatorListenerAdapter() {
-                    override fun onAnimationEnd(animation: Animator) {
-                        finishCallback?.run()
-                        inView.alpha = 1f
-                        outView?.alpha = 1f
-                    }
-                })
-            }.also {
-                it.start()
-            }
-    }
-
-    private fun findExistingTabView(nullableParent: ViewGroup?): View? {
-        val parent = nullableParent ?: return null
-        val viewCount = parent.childCount
-        for (childIdx in 0 until viewCount) {
-            val childView = parent.getChildAt(childIdx)
-            if (childView is TabView) {
-                return (childView as TabView).getView()
-            }
-        }
-        return null
-    }
-
-    private fun stopTabTransition() {
-        val animator = tabTransitionAnimator ?: return
-        if (animator.isRunning) {
-            animator.end()
-        }
-    }
-
-    private fun onTabAddedByContextMenu(tab: Session, arguments: Bundle) {
-        if (!TabUtil.toFocus(arguments)) {
-            val binding = browserFragment.binding ?: return
-            Snackbar.make(
-                binding.root,
-                R.string.new_background_tab_hint,
-                Snackbar.LENGTH_LONG
-            ).apply {
-                setAction(R.string.new_background_tab_switch) {
-                    browserFragment.sessionManager.switchToTab(tab.id)
-                }
-                anchorView = browserFragment.binding?.browserBottomBar
-            }.show()
-        }
-    }
-
-    override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-        sessionObserver.updateFailingUrl(url, updateFromError)
-    }
-
-    override fun handleExternalUrl(url: String?): Boolean {
-        return sessionObserver.handleExternalUrl(url)
-    }
-
-    override fun onShowFileChooser(
-        es: TabViewEngineSession,
-        filePathCallback: ValueCallback<Array<Uri>>?,
-        fileChooserParams: WebChromeClient.FileChooserParams?
-    ): Boolean {
-        return sessionObserver.onShowFileChooser(es, filePathCallback, fileChooserParams)
-    }
-
-    override fun onHttpAuthRequest(
-        callback: TabViewClient.HttpAuthCallback,
-        host: String?,
-        realm: String?
-    ) {
-        sessionObserver.onHttpAuthRequest(callback, host, realm)
-    }
-
-    private fun isStartedFromExternalApp(): Boolean {
-        // No SafeIntent needed here because intent.getAction() is safe (SafeIntent simply calls
-        // intent.getAction() without any wrapping):
-        val intent = browserFragment?.activity?.intent ?: return false
-        val isInternal = intent.getBooleanExtra(IntentUtils.EXTRA_IS_INTERNAL_REQUEST, false)
-        return !isInternal && Intent.ACTION_VIEW == intent.action
+        sessionCtrl.chromePromoteAddedSession(session)
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/browser/SessionObserver.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/SessionObserver.kt
@@ -2,146 +2,71 @@ package org.mozilla.rocket.browser
 
 import android.graphics.Bitmap
 import android.net.Uri
-import android.text.TextUtils
-import android.util.Log
 import android.view.View
-import android.view.ViewGroup
 import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
-import android.widget.FrameLayout
-import androidx.lifecycle.Lifecycle
-import org.mozilla.focus.menu.WebContextMenu
-import org.mozilla.focus.navigation.ScreenNavigator
+import mozilla.components.browser.session.Download
 import org.mozilla.focus.telemetry.TelemetryWrapper
-import org.mozilla.focus.utils.IntentUtils
-import org.mozilla.focus.utils.ViewUtils
-import org.mozilla.focus.web.HttpAuthenticationDialogBuilder
 import org.mozilla.rocket.history.SessionHistoryInserter
 import org.mozilla.rocket.tabs.Session
 import org.mozilla.rocket.tabs.TabView
 import org.mozilla.rocket.tabs.TabViewClient
 import org.mozilla.rocket.tabs.TabViewEngineSession
-import org.mozilla.rocket.tabs.web.Download
-import org.mozilla.rocket.tabs.web.DownloadCallback
+import org.mozilla.rocket.tabs.web.Download as RocketDownload
 
 class SessionObserver(
-    private val browserFragment: BrowserFragment
+    private val sessionCtrl: SessionController
 ) : Session.Observer, TabViewEngineSession.Client {
-    private var session: Session? = null
+
+    private var observingSession: Session? = null
+
     private val historyInserter = SessionHistoryInserter()
 
     // Some url may report progress from 0 again for the same url. filter them out to avoid
     // progress bar regression when scrolling.
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
-        browserFragment.isLoading = loading
         if (loading) {
             historyInserter.onTabStarted(session)
         } else {
-            historyInserter.onTabFinished(session, browserFragment.url)
+            sessionCtrl.chromeGetUrl()?.let {
+                historyInserter.onTabFinished(session, it)
+            }
         }
-        if (!isForegroundSession(session)) {
-            return
-        }
-        if (loading) {
-            browserFragment.loadedUrl = null
-            browserFragment.chromeViewModel.onPageLoadingStarted()
-            browserFragment.updateIsLoading(true)
-            browserFragment.updateURL(session.url)
-            browserFragment.appBarBgTransition.resetTransition()
-            browserFragment.statusBarBgTransition.resetTransition()
-        } else {
-            // The URL which is supplied in onTabFinished() could be fake (see #301), but webview's
-            // URL is always correct _except_ for error pages
-            updateUrlFromWebView(session)
-            browserFragment.chromeViewModel.onPageLoadingStopped()
-            browserFragment.updateIsLoading(false)
-            browserFragment.appBarBgTransition.startTransition(BrowserFragment.ANIMATION_DURATION)
-            browserFragment.statusBarBgTransition.startTransition(BrowserFragment.ANIMATION_DURATION)
+        if (session.isFocusing()) {
+            sessionCtrl.chromeUpdateLoadingState(session, loading)
         }
     }
 
     override fun onSecurityChanged(session: Session, isSecure: Boolean) {
-        val level = if (isSecure) BrowserFragment.SITE_LOCK else BrowserFragment.SITE_GLOBE
-        browserFragment.binding?.toolbar?.siteIdentity?.setImageLevel(level)
+        if (session.isFocusing()) {
+            sessionCtrl.chromeUpdateSiteIdentity(isSecure)
+        }
     }
 
     override fun onUrlChanged(session: Session, url: String?) {
-        browserFragment.chromeViewModel.onFocusedUrlChanged(url)
-        if (!isForegroundSession(session)) {
-            return
-        }
-        // Prevent updateURL when directly entering URL in the address bar.
-        if (browserFragment.chromeViewModel.openUrl.value?.url ?: "" != url) {
-            browserFragment.updateURL(url)
-        } else if (browserFragment.chromeViewModel.openUrl.value?.url ?: "" != "") {
-            browserFragment.chromeViewModel.openUrl.value!!.url = ""
+        if (session.isFocusing()) {
+            sessionCtrl.chromeChangeUrlOfFocusedSession(url)
         }
     }
 
     override fun handleExternalUrl(url: String?): Boolean {
-        if (browserFragment.context == null) {
-            Log.w(
-                ScreenNavigator.BROWSER_FRAGMENT_TAG,
-                "No context to use, abort callback handleExternalUrl"
-            )
-            return false
+        if (url != null) {
+            return sessionCtrl.chromeHandleExternalUrl(url)
         }
-        val navigationState = browserFragment.chromeViewModel.navigationState.value
-        if (navigationState != null && navigationState.isHome) {
-            val msg = "Ignore external url when browser page is not on the front"
-            Log.w(ScreenNavigator.BROWSER_FRAGMENT_TAG, msg)
-            return false
-        }
-        return IntentUtils.handleExternalUri(browserFragment.context, url)
+        return false
     }
 
     override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-        session?.let {
-            historyInserter.updateFailingUrl(it, url, updateFromError)
-        }
-    }
-
-    // Remove URL fragment to prevent progress bar update when location.hash change (follow Chrome and Firefox for Android behavior)
-    private fun removeUrlFragment(url: String): String {
-        val endPos: Int = when {
-            url.indexOf("#") > 0 -> url.indexOf("#")
-            else -> url.length
-        }
-        return url.substring(0, endPos)
+        val observing = observingSession ?: return
+        historyInserter.updateFailingUrl(observing, url, updateFromError)
     }
 
     override fun onProgress(session: Session, progress: Int) {
-        if (!isForegroundSession(session)) {
-            return
+        if (session.isFocusing()) {
+            sessionCtrl.chromeUpdateProgress(session, progress)
         }
-        browserFragment.hideFindInPage()
-        if (browserFragment.sessionManager.focusSession != null) {
-            val currentUrl = browserFragment.sessionManager.focusSession?.url
-            val progressIsForLoadedUrl =
-                TextUtils.equals(
-                    currentUrl?.let { removeUrlFragment(it) },
-                    browserFragment.loadedUrl?.let { removeUrlFragment(it) }
-                )
-            // Some new url may give 100 directly and then start from 0 again. don't treat
-            // as loaded for these urls;
-            val progressBar = browserFragment.binding?.progressBar
-            val urlBarLoadingToFinished = if (progressBar == null) {
-                false
-            } else {
-                progressBar.max != progressBar.progress && progress == progressBar.max
-            }
-            if (urlBarLoadingToFinished) {
-                browserFragment.loadedUrl = currentUrl
-            }
-            // Some URL cause progress bar to stuck at loading state,
-            // allowing progress update to progressBar.max solve the issue
-            if (progressIsForLoadedUrl && progress != progressBar?.max) {
-                return
-            }
-        }
-        browserFragment.binding?.progressBar?.progress = progress
     }
 
     override fun onShowFileChooser(
@@ -149,14 +74,14 @@ class SessionObserver(
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: WebChromeClient.FileChooserParams?
     ): Boolean {
-        if (!isForegroundSession(session)) {
+        if (!observingSession.isFocusing()) {
             return false
         }
         TelemetryWrapper.browseFilePermissionEvent()
         return try {
             requireNotNull(filePathCallback)
             requireNotNull(fileChooserParams)
-            browserFragment.chooseFile(filePathCallback, fileChooserParams)
+            sessionCtrl.chromeChooseFile(filePathCallback, fileChooserParams)
             true
         } catch (e: Exception) {
             e.printStackTrace()
@@ -165,92 +90,48 @@ class SessionObserver(
     }
 
     override fun onTitleChanged(session: Session, title: String?) {
-        browserFragment.chromeViewModel.onFocusedTitleChanged(title)
+        if (session.isFocusing()) {
+            sessionCtrl.chromeChangeFocusedSessionTitle(title)
+        }
     }
 
-    override fun onReceivedIcon(icon: Bitmap?) {}
+    override fun onReceivedIcon(icon: Bitmap?) = Unit
+
     override fun onLongPress(session: Session, hitTarget: TabView.HitTarget) {
-        if (browserFragment.activity == null) {
-            Log.w(
-                ScreenNavigator.BROWSER_FRAGMENT_TAG,
-                "No context to use, abort callback onLongPress"
-            )
-            return
+        if (session.isFocusing()) {
+            sessionCtrl.chromeShowLinkContextMenu(hitTarget)
         }
-        browserFragment.webContextMenu = WebContextMenu.show(
-            false,
-            browserFragment.requireActivity(),
-            BrowserDownloadCallback(browserFragment),
-            hitTarget
-        )
     }
 
     override fun onEnterFullScreen(callback: TabView.FullscreenCallback, view: View?) {
-        if (session == null) {
+        if (observingSession == null) {
             return
         }
-        val binding = browserFragment.binding ?: return
-        if (!isForegroundSession(session)) {
+        if (!observingSession.isFocusing()) {
             callback.fullScreenExited()
             return
         }
-        browserFragment.fullscreenCallback = callback
-        if (session?.engineSession?.tabView != null && view != null) {
-            // Hide browser UI and web content
-            binding.appBar.visibility = View.INVISIBLE
-            binding.webviewContainer.visibility = View.INVISIBLE
-            binding.browserBottomBar.visibility = View.INVISIBLE
-
-            // Add view to video container and make it visible
-            val params = FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
-            )
-            binding.videoContainer.addView(view, params)
-            binding.videoContainer.visibility = View.VISIBLE
-
-            browserFragment.hidePluggableUi()
-
-            // Switch to immersive mode: Hide system bars other UI controls
-            browserFragment.systemVisibility =
-                ViewUtils.switchToImmersiveMode(browserFragment.activity)
+        if (observingSession?.engineSession?.tabView != null && view != null) {
+            sessionCtrl.chromeEnterFullScreen(callback, view)
         }
     }
 
     override fun onExitFullScreen() {
-        if (session == null) {
+        if (observingSession == null) {
             return
         }
-        val binding = browserFragment.binding ?: return
-        // Remove custom video views and hide container
-        binding.videoContainer.removeAllViews()
-        binding.videoContainer.visibility = View.GONE
+        sessionCtrl.chromeExitFullScreen()
+    }
 
-        // Show browser UI and web content again
-        binding.appBar.visibility = View.VISIBLE
-        binding.webviewContainer.visibility = View.VISIBLE
-        binding.browserBottomBar.visibility = View.VISIBLE
-        if (browserFragment.systemVisibility != ViewUtils.SYSTEM_UI_VISIBILITY_NONE) {
-            ViewUtils.exitImmersiveMode(
-                browserFragment.systemVisibility,
-                browserFragment.activity
-            )
-        }
-        browserFragment.showPluggableUi()
-
-        // Notify renderer that we left fullscreen mode.
-        browserFragment.fullscreenCallback?.let {
-            it.fullScreenExited()
-            browserFragment.fullscreenCallback = null
-        }
-
+    fun clearFocusFromObservingSession() {
         // WebView gets focus, but unable to open the keyboard after exit Fullscreen for Android 7.0+
         // We guess some component in WebView might lock focus
-        // So when user touches the input text box on Webview, it will not trigger to open the keyboard
+        // So when user touches the input text box on WebView, it will not trigger to open the keyboard
         // It may be a WebView bug.
         // The workaround is clearing WebView focus
         // The WebView will be normal when it gets focus again.
         // If android change behavior after, can remove this.
-        session?.engineSession?.tabView?.let {
+        observingSession?.engineSession?.tabView?.let {
             if (it is WebView) {
                 it.clearFocus()
             }
@@ -261,49 +142,34 @@ class SessionObserver(
         origin: String,
         callback: GeolocationPermissions.Callback?
     ) {
-        if (session == null) {
+        if (callback == null) {
             return
         }
-        if (!isForegroundSession(session) || !browserFragment.isPopupWindowAllowed) {
-            return
+        if (observingSession.isFocusing()) {
+            sessionCtrl.chromeShowGeolocationPermission(origin, callback)
         }
-        browserFragment.showGeolocationPermission(origin, callback)
     }
 
-    fun changeSession(nextSession: Session?) {
-        session?.unregister(this)
-        session = nextSession?.also {
+    fun changeObservingSession(nextSession: Session?) {
+        observingSession?.unregister(this)
+        observingSession?.engineSession?.engineSessionClient = null
+        observingSession = nextSession?.also {
             it.register(this)
+            it.engineSession?.engineSessionClient = this
         }
-    }
-
-    private fun updateUrlFromWebView(source: Session) {
-        if (browserFragment.sessionManager.focusSession != null) {
-            val viewURL = browserFragment.sessionManager.focusSession?.url
-            onUrlChanged(source, viewURL)
-        }
-    }
-
-    private fun isForegroundSession(tab: Session?): Boolean {
-        return browserFragment.sessionManager.focusSession == tab
     }
 
     override fun onFindResult(
         session: Session,
         result: mozilla.components.browser.session.Session.FindResult
     ) {
-        browserFragment.findInPage.onFindResultReceived(result)
+        if (session.isFocusing()) {
+            sessionCtrl.chromeSetReceivedFindResult(result)
+        }
     }
 
-    override fun onDownload(
-        session: Session,
-        download: mozilla.components.browser.session.Download
-    ): Boolean {
-        val activity = browserFragment.activity
-        if (activity == null || !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-            return false
-        }
-        val d = Download(
+    override fun onDownload(session: Session, download: Download): Boolean {
+        val rocketDownload = RocketDownload(
             download.url,
             download.fileName,
             download.userAgent,
@@ -312,8 +178,7 @@ class SessionObserver(
             requireNotNull(download.contentLength),
             false
         )
-        browserFragment.maybeQueueDownload(d)
-        return true
+        return sessionCtrl.chromeQueueDownload(rocketDownload)
     }
 
     override fun onNavigationStateChanged(
@@ -321,7 +186,9 @@ class SessionObserver(
         canGoBack: Boolean,
         canGoForward: Boolean
     ) {
-        browserFragment.chromeViewModel.onNavigationStateChanged(canGoBack, canGoForward)
+        if (session.isFocusing()) {
+            sessionCtrl.chromeChangeNavigationState(canGoBack, canGoForward)
+        }
     }
 
     override fun onHttpAuthRequest(
@@ -329,23 +196,12 @@ class SessionObserver(
         host: String?,
         realm: String?
     ) {
-        // TODO: too complicated. should be refactor
-        val innerBuilder =
-            HttpAuthenticationDialogBuilder.Builder(browserFragment.activity, host, realm)
-        innerBuilder.setOkListener { _: String?, _: String?, username: String?, password: String? ->
-            callback.proceed(username, password)
+        if (host != null && realm != null) {
+            sessionCtrl.chromeShowHttpAuth(callback, host, realm)
         }
-        innerBuilder.setCancelListener { callback.cancel() }
-        val builder = innerBuilder.build()
-        builder.createDialog()
-        builder.show()
     }
 
-    private class BrowserDownloadCallback(
-        private val fragment: BrowserFragment
-    ) : DownloadCallback {
-        override fun onDownloadStart(download: Download) {
-            fragment.maybeQueueDownload(download)
-        }
+    private fun Session?.isFocusing(): Boolean {
+        return sessionCtrl.getFocusSession() == this
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/chrome/BottomBarItemAdapter.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/BottomBarItemAdapter.kt
@@ -283,7 +283,9 @@ class BottomBarItemAdapter(
     }
 
     private class MenuItem(
-        type: ItemType, id: Int, private val theme: Theme
+        type: ItemType,
+        id: Int,
+        private val theme: Theme
     ) : BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
@@ -294,7 +296,10 @@ class BottomBarItemAdapter(
                         theme.buttonColorResId
                     )
                     val downloadColorResId =
-                        if (theme == Theme.Light) R.color.paletteDarkBlueC100 else theme.buttonColorResId
+                        if (theme == Theme.Light)
+                            R.color.paletteDarkBlueC100
+                        else
+                            theme.buttonColorResId
                     findViewById<ThemedImageButton>(R.id.download_unread_indicator).setTint(
                         context,
                         downloadColorResId
@@ -304,7 +309,9 @@ class BottomBarItemAdapter(
     }
 
     private class BookmarkItem(
-        type: ItemType, id: Int, theme: Theme
+        type: ItemType,
+        id: Int,
+        theme: Theme
     ) : ImageItem(
         type,
         id,
@@ -352,7 +359,10 @@ class BottomBarItemAdapter(
             return LayoutInflater.from(context)
                 .inflate(R.layout.button_shopping_search, parent, false).apply {
                     val shoppingSearchColorResId =
-                        if (theme == Theme.ShoppingSearch) R.color.shoppingSearchIcon else theme.buttonColorResId
+                        if (theme == Theme.ShoppingSearch)
+                            R.color.shoppingSearchIcon
+                        else
+                            theme.buttonColorResId
                     findViewById<ThemedImageButton>(R.id.action_shopping_search).setTint(
                         context,
                         shoppingSearchColorResId

--- a/app/src/main/java/org/mozilla/rocket/chrome/BottomBarItemAdapter.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/BottomBarItemAdapter.kt
@@ -37,66 +37,70 @@ class BottomBarItemAdapter(
 
     private fun convertToItem(itemData: ItemData): BottomBarItem {
         return when (val type = itemData.type) {
-            TYPE_TAB_COUNTER -> TabCounterItem(type, R.id.bottom_bar_tab_counter, theme)
-            TYPE_MENU -> MenuItem(type, R.id.bottom_bar_menu, theme)
-            TYPE_HOME -> ImageItem(
+            ItemType.TAB_COUNTER -> TabCounterItem(type, R.id.bottom_bar_tab_counter, theme)
+            ItemType.MENU -> MenuItem(type, R.id.bottom_bar_menu, theme)
+            ItemType.HOME -> ImageItem(
                 type,
                 R.id.bottom_bar_home,
                 R.drawable.action_home,
                 theme.buttonColorResId
             )
-            TYPE_SEARCH -> ImageItem(
+            ItemType.SEARCH -> ImageItem(
                 type,
                 R.id.bottom_bar_search,
                 R.drawable.action_search,
                 theme.buttonColorResId
             )
-            TYPE_CAPTURE -> ImageItem(
+            ItemType.CAPTURE -> ImageItem(
                 type,
                 R.id.bottom_bar_capture,
                 R.drawable.action_capture,
                 theme.buttonColorResId
             )
-            TYPE_PIN_SHORTCUT -> ImageItem(
+            ItemType.PIN_SHORTCUT -> ImageItem(
                 type,
                 R.id.bottom_bar_pin_shortcut,
                 R.drawable.action_add_to_home,
                 theme.buttonColorResId
             )
-            TYPE_BOOKMARK -> BookmarkItem(type, R.id.bottom_bar_bookmark, theme)
-            TYPE_REFRESH -> RefreshItem(type, R.id.bottom_bar_refresh, theme)
-            TYPE_SHARE -> ImageItem(
+            ItemType.BOOKMARK -> BookmarkItem(type, R.id.bottom_bar_bookmark, theme)
+            ItemType.REFRESH -> RefreshItem(type, R.id.bottom_bar_refresh, theme)
+            ItemType.SHARE -> ImageItem(
                 type,
                 R.id.bottom_bar_share,
                 R.drawable.action_share,
                 theme.buttonColorResId
             )
-            TYPE_NEXT -> ImageItem(
+            ItemType.NEXT -> ImageItem(
                 type,
                 R.id.bottom_bar_next,
                 R.drawable.action_next,
                 theme.buttonColorResId
             )
-            TYPE_PRIVATE_HOME -> PrivateHomeItem(type, R.id.bottom_bar_private_home)
-            TYPE_DELETE -> ImageItem(
+            ItemType.PRIVATE_HOME -> PrivateHomeItem(type, R.id.bottom_bar_private_home)
+            ItemType.DELETE -> ImageItem(
                 type,
                 R.id.bottom_bar_delete,
                 R.drawable.menu_delete,
                 theme.buttonColorResId
             )
-            TYPE_TRACKER -> TrackerItem(type, R.id.bottom_bar_tracker)
-            TYPE_BACK -> ImageItem(
+            ItemType.TRACKER -> TrackerItem(type, R.id.bottom_bar_tracker)
+            ItemType.BACK -> ImageItem(
                 type,
                 R.id.bottom_bar_back,
                 R.drawable.action_back,
                 theme.buttonColorResId
             )
-            TYPE_SHOPPING_SEARCH -> ShoppingSearchItem(type, R.id.bottom_bar_shopping_search, theme)
+            ItemType.SHOPPING_SEARCH -> ShoppingSearchItem(
+                type,
+                R.id.bottom_bar_shopping_search,
+                theme
+            )
             else -> error("Unexpected BottomBarItem ItemType: $type")
         }
     }
 
-    fun getItem(type: Int): BottomBarItem? = items?.find { it.type == type }
+    fun getItem(type: ItemType): BottomBarItem? = items?.find { it.type == type }
 
     fun setEnabled(enabled: Boolean) {
         items?.forEach {
@@ -121,10 +125,10 @@ class BottomBarItemAdapter(
             val type = it.type
             when {
                 view is ThemedImageButton -> view.setDarkTheme(isNight)
-                type == TYPE_TAB_COUNTER -> (view as TabCounter).setDarkTheme(isNight)
-                type == TYPE_MENU -> view?.findViewById<ThemedImageButton>(R.id.btn_menu)
+                type == ItemType.TAB_COUNTER -> (view as TabCounter).setDarkTheme(isNight)
+                type == ItemType.MENU -> view?.findViewById<ThemedImageButton>(R.id.btn_menu)
                     ?.setDarkTheme(isNight)
-                type == TYPE_REFRESH -> {
+                type == ItemType.REFRESH -> {
                     view?.findViewById<ThemedImageButton>(R.id.action_refresh)
                         ?.setDarkTheme(isNight)
                     view?.findViewById<ThemedImageButton>(R.id.action_stop)?.setDarkTheme(isNight)
@@ -135,7 +139,7 @@ class BottomBarItemAdapter(
 
     @JvmOverloads
     fun setTabCount(count: Int, animationEnabled: Boolean = false) {
-        getItem(TYPE_TAB_COUNTER)?.view?.apply {
+        getItem(ItemType.TAB_COUNTER)?.view?.apply {
             this as TabCounter
             if (animationEnabled) {
                 setCountWithAnimation(count)
@@ -152,17 +156,17 @@ class BottomBarItemAdapter(
         }
     }
 
-    fun setDownloadState(state: Int) {
-        getItem(TYPE_MENU)?.view?.apply {
+    fun setDownloadState(state: DownloadState) {
+        getItem(ItemType.MENU)?.view?.apply {
             val stateIcon = findViewById<ImageView>(R.id.download_unread_indicator)
             val downloadingAnimationView =
                 findViewById<LottieAnimationView>(R.id.downloading_indicator)
             when (state) {
-                DOWNLOAD_STATE_DEFAULT -> {
+                DownloadState.DEFAULT -> {
                     stateIcon.visibility = View.GONE
                     downloadingAnimationView.visibility = View.GONE
                 }
-                DOWNLOAD_STATE_DOWNLOADING -> {
+                DownloadState.DOWNLOADING -> {
                     stateIcon.visibility = View.GONE
                     downloadingAnimationView.apply {
                         visibility = View.VISIBLE
@@ -171,33 +175,32 @@ class BottomBarItemAdapter(
                         }
                     }
                 }
-                DOWNLOAD_STATE_UNREAD -> {
+                DownloadState.UNREAD -> {
                     stateIcon.apply {
                         visibility = View.VISIBLE
                         setImageResource(R.drawable.notify_download)
                     }
                     downloadingAnimationView.visibility = View.GONE
                 }
-                DOWNLOAD_STATE_WARNING -> {
+                DownloadState.WARNING -> {
                     stateIcon.apply {
                         visibility = View.VISIBLE
                         setImageResource(R.drawable.notify_notice)
                     }
                     downloadingAnimationView.visibility = View.GONE
                 }
-                else -> error("Unexpected download state")
             }
         }
     }
 
     fun setBookmark(isBookmark: Boolean) {
-        getItem(TYPE_BOOKMARK)?.view?.apply {
+        getItem(ItemType.BOOKMARK)?.view?.apply {
             isActivated = isBookmark
         }
     }
 
     fun setRefreshing(isRefreshing: Boolean) {
-        getItem(TYPE_REFRESH)?.view?.apply {
+        getItem(ItemType.REFRESH)?.view?.apply {
             val refreshIcon = findViewById<ThemedImageButton>(R.id.action_refresh)
             val stopIcon = findViewById<ThemedImageButton>(R.id.action_stop)
             if (isRefreshing) {
@@ -211,31 +214,31 @@ class BottomBarItemAdapter(
     }
 
     fun setCanGoForward(canGoForward: Boolean) {
-        getItem(TYPE_NEXT)?.view?.apply {
+        getItem(ItemType.NEXT)?.view?.apply {
             isEnabled = canGoForward
         }
     }
 
     fun setCanGoBack(canGoBack: Boolean) {
-        getItem(TYPE_BACK)?.view?.apply {
+        getItem(ItemType.BACK)?.view?.apply {
             isEnabled = canGoBack
         }
     }
 
     fun animatePrivateHome() {
-        getItem(TYPE_PRIVATE_HOME)?.view?.apply {
+        getItem(ItemType.PRIVATE_HOME)?.view?.apply {
             findViewById<LottieAnimationView>(R.id.pm_home_mask).playAnimation()
         }
     }
 
     fun endPrivateHomeAnimation() {
-        getItem(TYPE_PRIVATE_HOME)?.view?.apply {
+        getItem(ItemType.PRIVATE_HOME)?.view?.apply {
             findViewById<LottieAnimationView>(R.id.pm_home_mask).progress = 1f
         }
     }
 
     fun setTrackerSwitch(isOn: Boolean) {
-        getItem(TYPE_TRACKER)?.view?.apply {
+        getItem(ItemType.TRACKER)?.view?.apply {
             val trackerOn = findViewById<LottieAnimationView>(R.id.btn_tracker_on)
             val trackerOff = findViewById<ImageButton>(R.id.btn_tracker_off)
             if (isOn) {
@@ -249,7 +252,7 @@ class BottomBarItemAdapter(
     }
 
     fun setTrackerBadgeEnabled(isEnabled: Boolean) {
-        getItem(TYPE_TRACKER)?.view?.apply {
+        getItem(ItemType.TRACKER)?.view?.apply {
             val trackerOn = findViewById<LottieAnimationView>(R.id.btn_tracker_on)
             if (isEnabled) {
                 val isAnimating = trackerOn.isAnimating
@@ -263,7 +266,7 @@ class BottomBarItemAdapter(
         }
     }
 
-    private class TabCounterItem(type: Int, id: Int, private val theme: Theme) :
+    private class TabCounterItem(type: ItemType, id: Int, private val theme: Theme) :
         BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             val contextThemeWrapper = ContextThemeWrapper(context, R.style.MainMenuButton)
@@ -279,7 +282,9 @@ class BottomBarItemAdapter(
         }
     }
 
-    private class MenuItem(type: Int, id: Int, private val theme: Theme) : BottomBarItem(type, id) {
+    private class MenuItem(
+        type: ItemType, id: Int, private val theme: Theme
+    ) : BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
                 .inflate(R.layout.button_more, parent, false)
@@ -298,14 +303,19 @@ class BottomBarItemAdapter(
         }
     }
 
-    private class BookmarkItem(type: Int, id: Int, theme: Theme) : ImageItem(
+    private class BookmarkItem(
+        type: ItemType, id: Int, theme: Theme
+    ) : ImageItem(
         type,
         id,
         R.drawable.ic_add_bookmark,
-        if (theme == Theme.Light) R.color.ic_add_bookmark_tint_light else R.color.ic_add_bookmark_tint_dark
+        if (theme == Theme.Light)
+            R.color.ic_add_bookmark_tint_light
+        else
+            R.color.ic_add_bookmark_tint_dark
     )
 
-    private class RefreshItem(type: Int, id: Int, private val theme: Theme) :
+    private class RefreshItem(type: ItemType, id: Int, private val theme: Theme) :
         BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
@@ -322,21 +332,21 @@ class BottomBarItemAdapter(
         }
     }
 
-    private class PrivateHomeItem(type: Int, id: Int) : BottomBarItem(type, id) {
+    private class PrivateHomeItem(type: ItemType, id: Int) : BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
                 .inflate(R.layout.button_private_to_normal, parent, false)
         }
     }
 
-    private class TrackerItem(type: Int, id: Int) : BottomBarItem(type, id) {
+    private class TrackerItem(type: ItemType, id: Int) : BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
                 .inflate(R.layout.button_tracker, parent, false)
         }
     }
 
-    private class ShoppingSearchItem(type: Int, id: Int, private val theme: Theme) :
+    private class ShoppingSearchItem(type: ItemType, id: Int, private val theme: Theme) :
         BottomBarItem(type, id) {
         override fun onCreateView(context: Context, parent: ViewGroup): View {
             return LayoutInflater.from(context)
@@ -358,30 +368,32 @@ class BottomBarItemAdapter(
         object ShoppingSearch : Theme(buttonColorResId = R.color.browser_menu_button)
     }
 
-    data class ItemData(val type: Int)
-
-    companion object {
-        const val TYPE_TAB_COUNTER = 0
-        const val TYPE_MENU = 1
-        const val TYPE_HOME = 2
-        const val TYPE_SEARCH = 3
-        const val TYPE_CAPTURE = 4
-        const val TYPE_PIN_SHORTCUT = 5
-        const val TYPE_BOOKMARK = 6
-        const val TYPE_REFRESH = 7
-        const val TYPE_SHARE = 8
-        const val TYPE_NEXT = 9
-        const val TYPE_PRIVATE_HOME = 10
-        const val TYPE_DELETE = 11
-        const val TYPE_TRACKER = 12
-        const val TYPE_BACK = 13
-        const val TYPE_SHOPPING_SEARCH = 14
-
-        const val DOWNLOAD_STATE_DEFAULT = 0
-        const val DOWNLOAD_STATE_DOWNLOADING = 1
-        const val DOWNLOAD_STATE_UNREAD = 2
-        const val DOWNLOAD_STATE_WARNING = 3
+    enum class DownloadState {
+        DEFAULT,
+        DOWNLOADING,
+        UNREAD,
+        WARNING
     }
+
+    enum class ItemType {
+        TAB_COUNTER,
+        MENU,
+        HOME,
+        SEARCH,
+        CAPTURE,
+        PIN_SHORTCUT,
+        BOOKMARK,
+        REFRESH,
+        SHARE,
+        NEXT,
+        PRIVATE_HOME,
+        DELETE,
+        TRACKER,
+        BACK,
+        SHOPPING_SEARCH,
+    }
+
+    data class ItemData(val type: ItemType)
 }
 
 private fun ImageView.setTint(context: Context, colorResId: Int) {

--- a/app/src/main/java/org/mozilla/rocket/chrome/BottomBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/BottomBarViewModel.kt
@@ -37,20 +37,20 @@ class BottomBarViewModel : ViewModel() {
     companion object {
         @JvmStatic
         val DEFAULT_BOTTOM_BAR_ITEMS: List<ItemData> = listOf(
-            ItemData(BottomBarItemAdapter.TYPE_HOME),
-            ItemData(BottomBarItemAdapter.TYPE_REFRESH),
-            ItemData(BottomBarItemAdapter.TYPE_SEARCH),
-            ItemData(BottomBarItemAdapter.TYPE_TAB_COUNTER),
-            ItemData(BottomBarItemAdapter.TYPE_MENU)
+            ItemData(BottomBarItemAdapter.ItemType.HOME),
+            ItemData(BottomBarItemAdapter.ItemType.REFRESH),
+            ItemData(BottomBarItemAdapter.ItemType.SEARCH),
+            ItemData(BottomBarItemAdapter.ItemType.TAB_COUNTER),
+            ItemData(BottomBarItemAdapter.ItemType.MENU)
         )
 
         @JvmStatic
         val DEFAULT_LANDSCAPE_BOTTOM_BAR_ITEMS: List<ItemData> = listOf(
-            ItemData(BottomBarItemAdapter.TYPE_HOME),
-            ItemData(BottomBarItemAdapter.TYPE_REFRESH),
-            ItemData(BottomBarItemAdapter.TYPE_SEARCH),
-            ItemData(BottomBarItemAdapter.TYPE_TAB_COUNTER),
-            ItemData(BottomBarItemAdapter.TYPE_SHARE)
+            ItemData(BottomBarItemAdapter.ItemType.HOME),
+            ItemData(BottomBarItemAdapter.ItemType.REFRESH),
+            ItemData(BottomBarItemAdapter.ItemType.SEARCH),
+            ItemData(BottomBarItemAdapter.ItemType.TAB_COUNTER),
+            ItemData(BottomBarItemAdapter.ItemType.SHARE)
         )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/ChromeViewModel.kt
@@ -57,6 +57,7 @@ class ChromeViewModel(
     var isCurrentUrlBookmarked: LiveData<Boolean> =
         currentUrl.switchMap(bookmarkRepo::getBookmarksByUrl).map { it.isNotEmpty() }
     val isRefreshing = MutableLiveData<Boolean>()
+    val isCurrentSessionSecure = MutableLiveData<Boolean>()
     val canGoBack = MutableLiveData<Boolean>()
     val canGoForward = MutableLiveData<Boolean>()
     val isHomePageUrlInputShowing = MutableLiveData<Boolean>()

--- a/app/src/main/java/org/mozilla/rocket/chrome/MenuViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/MenuViewModel.kt
@@ -15,7 +15,8 @@ class MenuViewModel(
 ) : ViewModel() {
     val bottomItems = MutableLiveData<List<BottomBarItemAdapter.ItemData>>()
     val shouldShowNewMenuItemHint: LiveData<Boolean> = shouldShowNewMenuItemHintUseCase()
-    val isHomeScreenShoppingSearchEnabled = MutableLiveData<Boolean>().apply { value = isHomeScreenShoppingButtonEnabledUseCase() }
+    val isHomeScreenShoppingSearchEnabled =
+        MutableLiveData<Boolean>().apply { value = isHomeScreenShoppingButtonEnabledUseCase() }
 
     init {
         refresh()
@@ -30,7 +31,8 @@ class MenuViewModel(
         }
     }
 
-    private fun getConfiguredBottomBarItems(): List<BottomBarItemAdapter.ItemData>? = AppConfigWrapper.getMenuBottomBarItems()
+    private fun getConfiguredBottomBarItems(): List<BottomBarItemAdapter.ItemData>? =
+        AppConfigWrapper.getMenuBottomBarItems()
 
     fun onNewMenuItemDisplayed() {
         readNewMenuItemsUseCase()
@@ -39,11 +41,11 @@ class MenuViewModel(
     companion object {
         @JvmStatic
         val DEFAULT_MENU_BOTTOM_ITEMS: List<BottomBarItemAdapter.ItemData> = listOf(
-            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.TYPE_BACK),
-            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.TYPE_NEXT),
-            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.TYPE_BOOKMARK),
-            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.TYPE_CAPTURE),
-            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.TYPE_SHARE)
+            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.ItemType.BACK),
+            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.ItemType.NEXT),
+            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.ItemType.BOOKMARK),
+            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.ItemType.CAPTURE),
+            BottomBarItemAdapter.ItemData(BottomBarItemAdapter.ItemType.SHARE)
         )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/chrome/PrivateBottomBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/chrome/PrivateBottomBarViewModel.kt
@@ -27,11 +27,11 @@ class PrivateBottomBarViewModel : ViewModel() {
     companion object {
         @JvmStatic
         val DEFAULT_PRIVATE_BOTTOM_BAR_ITEMS: List<ItemData> = Arrays.asList(
-            ItemData(BottomBarItemAdapter.TYPE_PRIVATE_HOME),
-            ItemData(BottomBarItemAdapter.TYPE_NEXT),
-            ItemData(BottomBarItemAdapter.TYPE_DELETE),
-            ItemData(BottomBarItemAdapter.TYPE_REFRESH),
-            ItemData(BottomBarItemAdapter.TYPE_TRACKER)
+            ItemData(BottomBarItemAdapter.ItemType.PRIVATE_HOME),
+            ItemData(BottomBarItemAdapter.ItemType.NEXT),
+            ItemData(BottomBarItemAdapter.ItemType.DELETE),
+            ItemData(BottomBarItemAdapter.ItemType.REFRESH),
+            ItemData(BottomBarItemAdapter.ItemType.TRACKER)
         )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabActivity.kt
@@ -211,12 +211,12 @@ class ContentTabActivity : BaseActivity(), TabsSessionProvider.SessionHost, Cont
     private fun setupBottomBar(bottomBar: BottomBar) {
         bottomBar.setOnItemClickListener { type, position ->
             when (type) {
-                BottomBarItemAdapter.TYPE_BACK -> chromeViewModel.goBack.call()
-                BottomBarItemAdapter.TYPE_REFRESH -> {
+                BottomBarItemAdapter.ItemType.BACK -> chromeViewModel.goBack.call()
+                BottomBarItemAdapter.ItemType.REFRESH -> {
                     chromeViewModel.refreshOrStop.call()
                     telemetryViewModel.onReloadButtonClicked()
                 }
-                BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
+                BottomBarItemAdapter.ItemType.SHARE -> chromeViewModel.share.call()
                 else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
             }
         }

--- a/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabBottomBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabBottomBarViewModel.kt
@@ -24,9 +24,9 @@ class ContentTabBottomBarViewModel : ViewModel() {
     companion object {
         @JvmStatic
         val DEFAULT_CONTENT_TAB_BOTTOM_BAR_ITEMS = listOf(
-            ItemData(BottomBarItemAdapter.TYPE_BACK),
-            ItemData(BottomBarItemAdapter.TYPE_REFRESH),
-            ItemData(BottomBarItemAdapter.TYPE_SHARE)
+            ItemData(BottomBarItemAdapter.ItemType.BACK),
+            ItemData(BottomBarItemAdapter.ItemType.REFRESH),
+            ItemData(BottomBarItemAdapter.ItemType.SHARE)
         )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabHelper.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/common/ui/ContentTabHelper.kt
@@ -140,7 +140,7 @@ class ContentTabHelper(private val contentTabViewContract: ContentTabViewContrac
     class Observer(
         private val contentTabViewContract: ContentTabViewContract,
         private val permissionHandler: PermissionHandler
-    ) : SessionManager.Observer, Session.Observer {
+    ) : SessionManager.Observer, Session.Observer, TabViewEngineSession.Client {
 
         private var systemVisibility = ViewUtils.SYSTEM_UI_VISIBILITY_NONE
 

--- a/app/src/main/java/org/mozilla/rocket/content/view/BottomBar.kt
+++ b/app/src/main/java/org/mozilla/rocket/content/view/BottomBar.kt
@@ -16,6 +16,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.behavior.HideBottomViewOnScrollBehavior
 import org.mozilla.focus.R
 import org.mozilla.focus.widget.EqualDistributeGrid
+import org.mozilla.rocket.chrome.BottomBarItemAdapter
 import org.mozilla.rocket.extension.dpToPx
 import org.mozilla.rocket.nightmode.themed.ThemedImageButton
 
@@ -149,14 +150,14 @@ open class BottomBar : FrameLayout, CoordinatorLayout.AttachedBehavior {
     }
 
     fun interface OnItemClickListener {
-        fun onItemClick(type: Int, position: Int): Unit
+        fun onItemClick(type: BottomBarItemAdapter.ItemType, position: Int): Unit
     }
 
     fun interface OnItemLongClickListener {
-        fun onItemLongClick(type: Int, position: Int): Boolean
+        fun onItemLongClick(type: BottomBarItemAdapter.ItemType, position: Int): Boolean
     }
 
-    abstract class BottomBarItem(val type: Int, val viewId: Int) {
+    abstract class BottomBarItem(val type: BottomBarItemAdapter.ItemType, val viewId: Int) {
         var view: View? = null
 
         fun createView(context: Context, parent: ViewGroup): View {
@@ -168,7 +169,7 @@ open class BottomBar : FrameLayout, CoordinatorLayout.AttachedBehavior {
         abstract fun onCreateView(context: Context, parent: ViewGroup): View
 
         open class ImageItem(
-            type: Int,
+            type: BottomBarItemAdapter.ItemType,
             id: Int,
             private val drawableResId: Int,
             private val tintResId: Int

--- a/app/src/main/java/org/mozilla/rocket/di/AppComponent.kt
+++ b/app/src/main/java/org/mozilla/rocket/di/AppComponent.kt
@@ -81,6 +81,7 @@ interface AppComponent {
     fun inject(editBookmarkActivity: EditBookmarkActivity)
     fun inject(bookmarksFragment: BookmarksFragment)
     fun inject(browserFragment: BrowserFragment)
+    fun inject(bottomBarController: org.mozilla.rocket.browser.BottomBarController)
     fun inject(shoppingSearchController: ShoppingSearchController)
     fun inject(browserFragment: org.mozilla.rocket.privately.browse.BrowserFragment)
     fun inject(browserFragmentLegacy: org.mozilla.rocket.privately.browse.BrowserFragmentLegacy)

--- a/app/src/main/java/org/mozilla/rocket/download/DownloadIndicatorIntroViewHelper.kt
+++ b/app/src/main/java/org/mozilla/rocket/download/DownloadIndicatorIntroViewHelper.kt
@@ -15,7 +15,7 @@ object DownloadIndicatorIntroViewHelper {
 
     private const val TOAST_DELAY_LONG = 3500L
 
-    interface OnViewInflated {
+    fun interface OnViewInflated {
         fun onInflated(view: View)
     }
 

--- a/app/src/main/java/org/mozilla/rocket/extension/CommonExtensions.kt
+++ b/app/src/main/java/org/mozilla/rocket/extension/CommonExtensions.kt
@@ -1,0 +1,12 @@
+package org.mozilla.rocket.extension
+
+/**
+ * Run a function if condition is true
+ *
+ * SomeCheckIfTrue().thenRun { block() }
+ */
+inline fun Boolean.thenRun(block: () -> Any) {
+    if (this) {
+        block()
+    }
+}

--- a/app/src/main/java/org/mozilla/rocket/extension/UrlStringExtension.kt
+++ b/app/src/main/java/org/mozilla/rocket/extension/UrlStringExtension.kt
@@ -1,0 +1,18 @@
+package org.mozilla.rocket.extension
+
+object UrlStringExtension {
+
+    /**
+     * Assume the given String is Url format, remove its fragment
+     */
+    fun String?.removeUrlFragment(): String? {
+        if (this == null) {
+            return null
+        }
+        val endPos: Int = when {
+            this.indexOf("#") > 0 -> this.indexOf("#")
+            else -> this.length
+        }
+        return this.substring(0, endPos)
+    }
+}

--- a/app/src/main/java/org/mozilla/rocket/menu/BrowserMenuDialog.kt
+++ b/app/src/main/java/org/mozilla/rocket/menu/BrowserMenuDialog.kt
@@ -20,6 +20,7 @@ import org.mozilla.focus.databinding.BottomSheetBrowserMenuBinding
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.utils.FormatUtils
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.chrome.MenuViewModel
 import org.mozilla.rocket.content.appComponent
@@ -231,47 +232,47 @@ class BrowserMenuDialog : LifecycleBottomSheetDialog {
         bottomBar.setOnItemClickListener { type, position ->
             cancel()
             when (type) {
-                BottomBarItemAdapter.TYPE_TAB_COUNTER -> {
+                ItemType.TAB_COUNTER -> {
                     chromeViewModel.showTabTray.call()
                     TelemetryWrapper.showTabTrayToolbar(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_MENU -> {
+                ItemType.MENU -> {
                     chromeViewModel.showBrowserMenu.call()
                     TelemetryWrapper.showMenuToolbar(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_HOME -> {
+                ItemType.HOME -> {
                     chromeViewModel.showNewTab.call()
                     TelemetryWrapper.clickAddTabToolbar(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_SEARCH -> {
+                ItemType.SEARCH -> {
                     chromeViewModel.showUrlInput.call()
                     TelemetryWrapper.clickToolbarSearch(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_CAPTURE -> chromeViewModel.onDoScreenshot(
+                ItemType.CAPTURE -> chromeViewModel.onDoScreenshot(
                     ChromeViewModel.ScreenCaptureTelemetryData(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 )
-                BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> {
+                ItemType.PIN_SHORTCUT -> {
                     chromeViewModel.pinShortcut.call()
                     TelemetryWrapper.clickAddToHome(TelemetryWrapper.Extra_Value.MENU, position)
                 }
-                BottomBarItemAdapter.TYPE_BOOKMARK -> {
-                    val isActivated =
-                        bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_BOOKMARK)?.view?.isActivated == true
+                ItemType.BOOKMARK -> {
+                    val nullableItem = bottomBarItemAdapter.getItem(ItemType.BOOKMARK)
+                    val isActivated = nullableItem?.view?.isActivated == true
                     TelemetryWrapper.clickToolbarBookmark(
                         !isActivated,
                         TelemetryWrapper.Extra_Value.MENU,
@@ -279,32 +280,36 @@ class BrowserMenuDialog : LifecycleBottomSheetDialog {
                     )
                     chromeViewModel.toggleBookmark()
                 }
-                BottomBarItemAdapter.TYPE_REFRESH -> {
+                ItemType.REFRESH -> {
                     chromeViewModel.refreshOrStop.call()
                     TelemetryWrapper.clickToolbarReload(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_SHARE -> {
+                ItemType.SHARE -> {
                     chromeViewModel.share.call()
                     TelemetryWrapper.clickToolbarShare(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_NEXT -> {
+                ItemType.NEXT -> {
                     chromeViewModel.goNext.call()
                     TelemetryWrapper.clickToolbarForward(
                         TelemetryWrapper.Extra_Value.MENU,
                         position
                     )
                 }
-                BottomBarItemAdapter.TYPE_BACK -> {
+                ItemType.BACK -> {
                     chromeViewModel.goBack.call()
                     TelemetryWrapper.clickToolbarBack(position)
                 }
-                else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+                ItemType.PRIVATE_HOME,
+                ItemType.DELETE,
+                ItemType.TRACKER,
+                ItemType.SHOPPING_SEARCH ->
+                    throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
             } // move Telemetry to ScreenCaptureTask doInBackground() cause we need to init category first.
         }
         bottomBarItemAdapter = BottomBarItemAdapter(bottomBar, BottomBarItemAdapter.Theme.Light)
@@ -330,7 +335,7 @@ class BrowserMenuDialog : LifecycleBottomSheetDialog {
             ShortcutManagerCompat.isRequestPinShortcutSupported(context)
         if (!requestPinShortcutSupported) {
             val pinShortcutItem =
-                bottomBarItemAdapter.getItem(BottomBarItemAdapter.TYPE_PIN_SHORTCUT)
+                bottomBarItemAdapter.getItem(ItemType.PIN_SHORTCUT)
             pinShortcutItem?.view?.apply {
                 visibility = View.GONE
             }

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -46,6 +46,7 @@ import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.permissionhandler.PermissionHandle
 import org.mozilla.permissionhandler.PermissionHandler
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.chrome.PrivateBottomBarViewModel
 import org.mozilla.rocket.content.app
@@ -176,9 +177,9 @@ class BrowserFragment :
 
                     if (PackageManager.PERMISSION_GRANTED ==
                         ContextCompat.checkSelfPermission(
-                                it,
-                                Manifest.permission.WRITE_EXTERNAL_STORAGE
-                            )
+                            it,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        )
                     ) {
                         // We do have the permission to write to the external storage. Proceed with the download.
                         queueDownload(download)
@@ -450,20 +451,21 @@ class BrowserFragment :
         val bottomBar = rootView.findViewById<BottomBar>(R.id.browser_bottom_bar)
         bottomBar.setOnItemClickListener { type, position ->
             when (type) {
-                BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.setValue(
+                ItemType.SEARCH -> chromeViewModel.showUrlInput.setValue(
                     chromeViewModel.currentUrl.value
                 )
-                BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
-                BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
-                BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
-                BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
-                BottomBarItemAdapter.TYPE_PRIVATE_HOME -> {
+                ItemType.PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
+                ItemType.REFRESH -> chromeViewModel.refreshOrStop.call()
+                ItemType.SHARE -> chromeViewModel.share.call()
+                ItemType.NEXT -> chromeViewModel.goNext.call()
+                ItemType.PRIVATE_HOME -> {
                     chromeViewModel.togglePrivateMode.call()
                     TelemetryWrapper.togglePrivateMode(true)
                 }
-                BottomBarItemAdapter.TYPE_DELETE -> onDeleteClicked()
-                BottomBarItemAdapter.TYPE_TRACKER -> onTrackerButtonClicked()
-                else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
+                ItemType.DELETE -> onDeleteClicked()
+                ItemType.TRACKER -> onTrackerButtonClicked()
+                else ->
+                    throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
             }
         }
         bottomBarItemAdapter =

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragment.kt
@@ -1,6 +1,6 @@
 package org.mozilla.rocket.privately.browse
 
-import android.Manifest
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -176,10 +176,7 @@ class BrowserFragment :
                     val download = params as Download
 
                     if (PackageManager.PERMISSION_GRANTED ==
-                        ContextCompat.checkSelfPermission(
-                            it,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE
-                        )
+                        ContextCompat.checkSelfPermission(it, WRITE_EXTERNAL_STORAGE)
                     ) {
                         // We do have the permission to write to the external storage. Proceed with the download.
                         queueDownload(download)
@@ -231,7 +228,7 @@ class BrowserFragment :
 
             override fun requestPermissions(actionId: Int) {
                 this@BrowserFragment.requestPermissions(
-                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                    arrayOf(WRITE_EXTERNAL_STORAGE),
                     actionId
                 )
             }
@@ -606,7 +603,7 @@ class BrowserFragment :
             )
             permissionHandler.tryAction(
                 this@BrowserFragment,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                WRITE_EXTERNAL_STORAGE,
                 ACTION_DOWNLOAD,
                 d
             )
@@ -713,7 +710,7 @@ class BrowserFragment :
 
             fragment.permissionHandler.tryAction(
                 fragment,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                WRITE_EXTERNAL_STORAGE,
                 ACTION_DOWNLOAD,
                 download
             )

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
@@ -509,7 +509,9 @@ class BrowserFragmentLegacy :
 
     class Observer(val fragment: BrowserFragmentLegacy) :
         SessionManager.Observer,
-        Session.Observer {
+        Session.Observer,
+        TabViewEngineSession.Client {
+
         override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
             // do nothing, exist for interface compatibility only.
         }

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
@@ -42,6 +42,7 @@ import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.permissionhandler.PermissionHandle
 import org.mozilla.permissionhandler.PermissionHandler
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.chrome.PrivateBottomBarViewModel
 import org.mozilla.rocket.content.appComponent
@@ -188,9 +189,9 @@ class BrowserFragmentLegacy :
 
                     if (PackageManager.PERMISSION_GRANTED ==
                         ContextCompat.checkSelfPermission(
-                                it,
-                                Manifest.permission.WRITE_EXTERNAL_STORAGE
-                            )
+                            it,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        )
                     ) {
                         // We do have the permission to write to the external storage. Proceed with the download.
                         queueDownload(download)
@@ -415,19 +416,19 @@ class BrowserFragmentLegacy :
         val bottomBar = rootView.findViewById<BottomBar>(R.id.browser_bottom_bar)
         bottomBar.setOnItemClickListener { type, position ->
             when (type) {
-                BottomBarItemAdapter.TYPE_SEARCH -> chromeViewModel.showUrlInput.setValue(
+                ItemType.SEARCH -> chromeViewModel.showUrlInput.setValue(
                     chromeViewModel.currentUrl.value
                 )
-                BottomBarItemAdapter.TYPE_PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
-                BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
-                BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
-                BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
-                BottomBarItemAdapter.TYPE_PRIVATE_HOME -> {
+                ItemType.PIN_SHORTCUT -> chromeViewModel.pinShortcut.call()
+                ItemType.REFRESH -> chromeViewModel.refreshOrStop.call()
+                ItemType.SHARE -> chromeViewModel.share.call()
+                ItemType.NEXT -> chromeViewModel.goNext.call()
+                ItemType.PRIVATE_HOME -> {
                     chromeViewModel.togglePrivateMode.call()
                     TelemetryWrapper.togglePrivateMode(true)
                 }
-                BottomBarItemAdapter.TYPE_DELETE -> onDeleteClicked()
-                BottomBarItemAdapter.TYPE_TRACKER -> onTrackerButtonClicked()
+                ItemType.DELETE -> onDeleteClicked()
+                ItemType.TRACKER -> onTrackerButtonClicked()
                 else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
             }
         }

--- a/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/browse/BrowserFragmentLegacy.kt
@@ -1,6 +1,6 @@
 package org.mozilla.rocket.privately.browse
 
-import android.Manifest
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
@@ -188,10 +188,7 @@ class BrowserFragmentLegacy :
                     val download = params as Download
 
                     if (PackageManager.PERMISSION_GRANTED ==
-                        ContextCompat.checkSelfPermission(
-                            it,
-                            Manifest.permission.WRITE_EXTERNAL_STORAGE
-                        )
+                        ContextCompat.checkSelfPermission(it, WRITE_EXTERNAL_STORAGE)
                     ) {
                         // We do have the permission to write to the external storage. Proceed with the download.
                         queueDownload(download)
@@ -243,7 +240,7 @@ class BrowserFragmentLegacy :
 
             override fun requestPermissions(actionId: Int) {
                 this@BrowserFragmentLegacy.requestPermissions(
-                    arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE),
+                    arrayOf(WRITE_EXTERNAL_STORAGE),
                     actionId
                 )
             }
@@ -649,7 +646,7 @@ class BrowserFragmentLegacy :
             )
             fragment.permissionHandler.tryAction(
                 fragment,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                WRITE_EXTERNAL_STORAGE,
                 ACTION_DOWNLOAD,
                 d
             )
@@ -700,7 +697,7 @@ class BrowserFragmentLegacy :
 
             fragment.permissionHandler.tryAction(
                 fragment,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                WRITE_EXTERNAL_STORAGE,
                 ACTION_DOWNLOAD,
                 download
             )

--- a/app/src/main/java/org/mozilla/rocket/shopping/search/ShoppingSearchController.kt
+++ b/app/src/main/java/org/mozilla/rocket/shopping/search/ShoppingSearchController.kt
@@ -62,7 +62,7 @@ class ShoppingSearchController(private val fragment: BrowserFragment) : Lifecycl
     }
 
     fun notifyUrlChanged() {
-        shoppingSearchPromptViewModel.checkShoppingSearchPromptVisibility(fragment.url)
+        shoppingSearchPromptViewModel.checkShoppingSearchPromptVisibility(fragment.chromeUrl)
     }
 
     private fun observeShoppingSearchPromptMessageViewModel() {
@@ -85,7 +85,7 @@ class ShoppingSearchController(private val fragment: BrowserFragment) : Lifecycl
         }
 
         shoppingSearchPromptViewModel.shoppingSiteList.observeOnViewLifecycle {
-            shoppingSearchPromptViewModel.checkShoppingSearchPromptVisibility(fragment.url)
+            shoppingSearchPromptViewModel.checkShoppingSearchPromptVisibility(fragment.chromeUrl)
         }
     }
 

--- a/app/src/main/java/org/mozilla/rocket/shopping/search/ui/ShoppingSearchBottomBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/rocket/shopping/search/ui/ShoppingSearchBottomBarViewModel.kt
@@ -24,11 +24,11 @@ class ShoppingSearchBottomBarViewModel : ViewModel() {
     companion object {
         @JvmStatic
         val DEFAULT_CONTENT_TAB_BOTTOM_BAR_ITEMS = listOf(
-            ItemData(BottomBarItemAdapter.TYPE_HOME),
-            ItemData(BottomBarItemAdapter.TYPE_REFRESH),
-            ItemData(BottomBarItemAdapter.TYPE_SHOPPING_SEARCH),
-            ItemData(BottomBarItemAdapter.TYPE_NEXT),
-            ItemData(BottomBarItemAdapter.TYPE_SHARE)
+            ItemData(BottomBarItemAdapter.ItemType.HOME),
+            ItemData(BottomBarItemAdapter.ItemType.REFRESH),
+            ItemData(BottomBarItemAdapter.ItemType.SHOPPING_SEARCH),
+            ItemData(BottomBarItemAdapter.ItemType.NEXT),
+            ItemData(BottomBarItemAdapter.ItemType.SHARE)
         )
     }
 }

--- a/app/src/main/java/org/mozilla/rocket/shopping/search/ui/ShoppingSearchResultTabFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/shopping/search/ui/ShoppingSearchResultTabFragment.kt
@@ -26,6 +26,7 @@ import org.mozilla.focus.databinding.FragmentShoppingSearchResultTabBinding
 import org.mozilla.focus.utils.AppConstants
 import org.mozilla.focus.widget.BackKeyHandleable
 import org.mozilla.rocket.chrome.BottomBarItemAdapter
+import org.mozilla.rocket.chrome.BottomBarItemAdapter.ItemType
 import org.mozilla.rocket.chrome.ChromeViewModel
 import org.mozilla.rocket.content.appComponent
 import org.mozilla.rocket.content.common.ui.ContentTabFragment
@@ -242,11 +243,12 @@ class ShoppingSearchResultTabFragment : Fragment(), ContentTabViewContract, Back
     private fun setupBottomBar(binding: FragmentShoppingSearchResultTabBinding) {
         binding.bottomBar.setOnItemClickListener { type, position ->
             when (type) {
-                BottomBarItemAdapter.TYPE_HOME -> sendHomeIntent(requireContext())
-                BottomBarItemAdapter.TYPE_REFRESH -> chromeViewModel.refreshOrStop.call()
-                BottomBarItemAdapter.TYPE_SHOPPING_SEARCH -> shoppingSearchResultViewModel.onShoppingSearchButtonClick()
-                BottomBarItemAdapter.TYPE_NEXT -> chromeViewModel.goNext.call()
-                BottomBarItemAdapter.TYPE_SHARE -> chromeViewModel.share.call()
+                ItemType.HOME -> sendHomeIntent(requireContext())
+                ItemType.REFRESH -> chromeViewModel.refreshOrStop.call()
+                ItemType.NEXT -> chromeViewModel.goNext.call()
+                ItemType.SHARE -> chromeViewModel.share.call()
+                ItemType.SHOPPING_SEARCH ->
+                    shoppingSearchResultViewModel.onShoppingSearchButtonClick()
                 else -> throw IllegalArgumentException("Unhandled bottom bar item, type: $type")
             }
         }

--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -5,15 +5,11 @@
 
 package org.mozilla.rocket.tabs
 
-import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.text.TextUtils
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
-import mozilla.components.support.base.observer.Consumable
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import org.mozilla.rocket.tabs.SessionManager.Factor.FACTOR_BACK_EXTERNAL
@@ -278,7 +274,6 @@ class SessionManager @JvmOverloads constructor(
             engineSession.register(observer)
         }
         engineSession.windowClient = WindowClient(session)
-        engineSession.engineSessionClient = Client()
         session.engineSession = engineSession
     }
 
@@ -414,35 +409,6 @@ class SessionManager @JvmOverloads constructor(
         }
     }
 
-    internal inner class Client : TabViewEngineSession.Client {
-        override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-            notifyObservers { updateFailingUrl(url, updateFromError) }
-        }
-
-        override fun handleExternalUrl(url: String?): Boolean {
-            val consumers: List<(String?) -> Boolean> = wrapConsumers { handleExternalUrl(it) }
-            return Consumable.from(url).consumeBy(consumers)
-        }
-
-        override fun onShowFileChooser(
-            es: TabViewEngineSession,
-            filePathCallback: ValueCallback<Array<Uri>>?,
-            fileChooserParams: WebChromeClient.FileChooserParams?
-        ): Boolean {
-            val consumers: List<(WebChromeClient.FileChooserParams?) -> Boolean> =
-                wrapConsumers { onShowFileChooser(es, filePathCallback, it) }
-            return Consumable.from(fileChooserParams).consumeBy(consumers)
-        }
-
-        override fun onHttpAuthRequest(
-            callback: TabViewClient.HttpAuthCallback,
-            host: String?,
-            realm: String?
-        ) {
-            notifyObservers { onHttpAuthRequest(callback, host, realm) }
-        }
-    }
-
     /**
      * A class to attach to UI thread for sending message.
      */
@@ -516,7 +482,7 @@ class SessionManager @JvmOverloads constructor(
         FACTOR_BACK_EXTERNAL(6)
     }
 
-    interface Observer : TabViewEngineSession.Client {
+    interface Observer {
         /**
          * Notify the host application a tab becomes 'focused tab'. It usually happens when adding,
          * removing or switching tabs.

--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.kt
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/SessionManagerTest.kt
@@ -6,13 +6,10 @@
 package org.mozilla.rocket.tabs
 
 import android.graphics.Bitmap
-import android.net.Uri
 import android.os.Bundle
 import android.os.Message
 import android.text.TextUtils
 import android.view.View
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
 import junit.framework.Assert
 import org.junit.After
 import org.junit.Before
@@ -195,30 +192,6 @@ class SessionManagerTest {
     fun testAddTab5() {
         // Add a tab from internal and focus it. onFocusChanged should be invoked once
         val spy0 = spy(object : Observer {
-            override fun onHttpAuthRequest(
-                callback: TabViewClient.HttpAuthCallback,
-                host: String?,
-                realm: String?
-            ) {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun handleExternalUrl(url: String?): Boolean {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun onShowFileChooser(
-                es: TabViewEngineSession,
-                filePathCallback: ValueCallback<Array<Uri>>?,
-                fileChooserParams: WebChromeClient.FileChooserParams?
-            ): Boolean {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
             override fun onFocusChanged(tab: Session?, factor: Factor) {
                 Assert.assertEquals(tab!!.url, "url0")
             }
@@ -235,30 +208,6 @@ class SessionManagerTest {
 
         // Add a tab from external. onFocusChanged should be invoked
         val spy1 = spy(object : Observer {
-            override fun onHttpAuthRequest(
-                callback: TabViewClient.HttpAuthCallback,
-                host: String?,
-                realm: String?
-            ) {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun updateFailingUrl(url: String?, updateFromError: Boolean) {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun handleExternalUrl(url: String?): Boolean {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
-            override fun onShowFileChooser(
-                es: TabViewEngineSession,
-                filePathCallback: ValueCallback<Array<Uri>>?,
-                fileChooserParams: WebChromeClient.FileChooserParams?
-            ): Boolean {
-                TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
-            }
-
             override fun onFocusChanged(tab: Session?, factor: Factor) {
                 Assert.assertEquals(tab!!.url, "url1")
             }


### PR DESCRIPTION
This PR almost re-architect the whole normal BrowserFragment.

A SessionController is involved, that is in charge of interacting with SessionManagerObserver and Observer for BrowserFragment. And abstracting BrowserFragment for both Observers.

```
    +--------------------+     +-------------------+    +----------------------+
    |  chromeViewModel   |<--->|                   |<-->|SessionManagerObserver|
    +----------^---------+     |                   |    +----------------------+
               |               | SessionController |    +----------------------+
    +----------v---------+     |                   |<-->|   SessionObserver    |
    |  BrowserFragment   |<--->|                   |    |                      |
    +--------------------+     +-------------------+    +----------------------+
 
```


This PR is huge, and it is possible to cause any obscure regression. It is also worth to do, to make BroserFragment being easier for maintaining.
