### PR TITLE
session: fix crash when opening url with blank target

### DIFF
--- a/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
+++ b/components/feature/tabs/src/main/java/org/mozilla/rocket/tabs/SessionManager.kt
@@ -251,7 +251,7 @@ class SessionManager @JvmOverloads constructor(
         }
     }
 
-    private fun initializeEngineView(session: Session) {
+    private fun initializeEngineView(session: Session, shouldLoadUrl: Boolean = true) {
         if (session.engineSession == null) {
             getOrCreateEngineSession(session)
         }
@@ -263,7 +263,9 @@ class SessionManager @JvmOverloads constructor(
         if (webViewState != null) {
             tabView.restoreViewState(webViewState)
         } else {
-            url?.let { tabView.loadUrl(it) }
+            if (shouldLoadUrl) {
+                url?.let { tabView.loadUrl(it) }
+            }
         }
     }
 
@@ -296,7 +298,8 @@ class SessionManager @JvmOverloads constructor(
         parentId: String?,
         fromExternal: Boolean,
         toFocus: Boolean,
-        arguments: Bundle?
+        arguments: Bundle?,
+        shouldLoadUrl: Boolean = true
     ): String {
 
         val tab = Session()
@@ -315,7 +318,7 @@ class SessionManager @JvmOverloads constructor(
         focusRef = if (toFocus || fromExternal) WeakReference(tab) else focusRef
 
         getOrCreateEngineSession(tab)
-        initializeEngineView(tab)
+        initializeEngineView(tab, shouldLoadUrl = shouldLoadUrl)
 
         if (toFocus || fromExternal) {
             notifier.notifyTabFocused(tab, FACTOR_TAB_ADDED)
@@ -386,11 +389,15 @@ class SessionManager @JvmOverloads constructor(
                 return false
             }
 
+            // a WebView instance is just created and will be filled by Message instance, so no need
+            // to load url manually. Otherwise we will got a crash.
             val id = addTabInternal(
                 null,
                 source.id,
                 false,
-                isUserGesture, null
+                isUserGesture,
+                null,
+                shouldLoadUrl = false
             )
 
             val tab = getTab(id) ?: return false // FIXME: why null?


### PR DESCRIPTION
for case of `<a href="..." target="_blank">....`, a crash will happen.

In `SessionManager.WindowClient.onCreateWindow`, it also called `loadUrl` in `initializeEngineView` for new created WebView, even if the WebView will be filled by `android.os.Message`. Then a crash happens

> New WebView for popup window must not have been  previously navigated

To solve the problem: if the new WebView will be filled by Message, do not call `WebView.loadUrl`.

This crash exists for long time, but was covered by `webViewClient.shouldOverrideUrlLoading`

In `WebKitView.loadUrl`, we called `shouldOverrideUrlLoading` which returns true, so we don't actually call loadUrl - we were lucky.

In commit 0f793a7bc536815ce28e801db3f0a8725b7adc6d we did not glue two interfaces anymore. (Instead, `TabViewEngineSession.Client` is assigned in `SessionObserver.changeObservingSession`), at the moment of calling `SessionManager.initializeEngineView`, the `WebkitView.webViewClient` is still `null`, so this crash became visible.