### PR TITLE
telemetry: do not send telemetry data in private mode process

### DIFF
--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -17,6 +17,7 @@ import android.preference.PreferenceManager
 import android.util.Log
 import android.webkit.PermissionRequest
 import org.mozilla.focus.BuildConfig
+import org.mozilla.focus.FocusApplication
 import org.mozilla.focus.R
 import org.mozilla.focus.telemetry.TelemetryWrapper.FIND_IN_PAGE.CLICK_NEXT
 import org.mozilla.focus.telemetry.TelemetryWrapper.FIND_IN_PAGE.CLICK_PREVIOUS
@@ -3498,7 +3499,11 @@ object TelemetryWrapper {
         }
 
         fun queue() {
-            firebaseEvent.event(appContext)
+            val isInPrivateProcess = (appContext as? FocusApplication)?.isInPrivateProcess ?: false
+            // do not send telemetry data in private process
+            if (!isInPrivateProcess) {
+                firebaseEvent.event(appContext)
+            }
         }
 
         companion object {


### PR DESCRIPTION
also for #28 

Since Private Mode is using same BrowserFragment as Normal Mode, disable telemetry in private mode process is easier and safer.

We don't have strong reason to collect user action since no UX designer is here.