### PR TITLE
private: do not always close private mode by back key

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -269,14 +269,20 @@ class PrivateModeActivity :
         }
 
         if (!this.screenNavigator.canGoBack()) {
-            checkShortcutPromotion {
-                TelemetryWrapper.exitPrivateMode(TelemetryWrapper.Extra_Value.SYSTEM_BACK)
-                finish()
-            }
+            checkShortcutPromotion { maybeClosePrivateMode() }
             return
         }
 
         super.onBackPressed()
+    }
+
+    private fun maybeClosePrivateMode() {
+        TelemetryWrapper.exitPrivateMode(TelemetryWrapper.Extra_Value.SYSTEM_BACK)
+        if (chromeViewModel.tabCount.value == 0) {
+            finish()
+        } else {
+            pushToBack()
+        }
     }
 
     override fun getSessionManager(): org.mozilla.rocket.tabs.SessionManager {


### PR DESCRIPTION
When pressing back key, Rocket might show HomeScreen if we reach beginning of one tab. (namely, no Previous Page in Histroy Stack).

If we click Back key again, Private Mode will close its activity.

Since we started supporting Multple Tabs in Private Mode, we should change the behavior to align Normal Mode.