### PR TITLE
Fix private mode crash in 2.7.0 release

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/privately/PrivateModeActivity.kt
@@ -70,7 +70,7 @@ class PrivateModeActivity :
 
     private lateinit var sessionManager: SessionManager
 
-    // TODO: remove after AC browser engine is stable
+    // TODO: remove it after the SessionController interface has been refactored
     private var sessionManagerLegacy: org.mozilla.rocket.tabs.SessionManager? = null
     private lateinit var chromeViewModel: ChromeViewModel
     private lateinit var tabViewProvider: PrivateTabViewProvider
@@ -92,9 +92,7 @@ class PrivateModeActivity :
         val bottomBarViewModel = getViewModel(bottomBarViewModelCreator)
         bottomBarViewModel.isInPrivateMode = true
 
-        if (isAcBrowserEngineEnabled()) {
-            sessionManager = app().sessionManager
-        }
+        sessionManager = app().sessionManager
 
         tabViewProvider = PrivateTabViewProvider(this)
         screenNavigator = ScreenNavigator(this)
@@ -109,12 +107,7 @@ class PrivateModeActivity :
 
         handleIntent(intent)
 
-        val layoutRes = if (isAcBrowserEngineEnabled()) {
-            R.layout.activity_private_mode
-        } else {
-            R.layout.activity_private_mode_legacy
-        }
-        setContentView(layoutRes)
+        setContentView(R.layout.activity_private_mode)
 
         setUpMenu()
         snackBarContainer = findViewById(R.id.container)
@@ -221,19 +214,11 @@ class PrivateModeActivity :
         var sessionUrl = ""
         var sessionTitle = ""
         var sessionIcon: Bitmap? = null
-        if (isAcBrowserEngineEnabled()) {
-            sessionManager.selectedSession?.let {
-                sessionUrl = it.url
-                sessionIcon = it.icon
-                sessionTitle = it.title
-            }
-        } else {
-            getSessionManager().focusSession?.let {
-                sessionUrl = it.url ?: ""
-                sessionIcon = it.favicon
-                sessionTitle = it.title
-            }
-        } ?: return
+        sessionManager.selectedSession?.let {
+            sessionUrl = it.url
+            sessionIcon = it.icon
+            sessionTitle = it.title
+        }
 
         // If we pin an invalid url as shortcut, the app will not function properly.
         // TODO: only enable the bottom menu item if the page is valid and loaded.
@@ -387,9 +372,7 @@ class PrivateModeActivity :
     }
 
     private fun stopPrivateMode(removeTask: Boolean) {
-        if (isAcBrowserEngineEnabled()) {
-            sessionManager.removeAll()
-        }
+        sessionManager.removeAll()
         PrivateSessionNotificationService.stop(this)
         PrivateMode.getInstance(this).sanitize()
         tabViewProvider.purify(this)
@@ -450,11 +433,5 @@ class PrivateModeActivity :
     companion object {
         fun getStartIntent(context: Context): Intent =
             Intent(context, PrivateModeActivity::class.java)
-
-        // TODO: remove after AC browser engine is stable
-        private fun isAcBrowserEngineEnabled() =
-            AppConstants.isNightlyBuild() ||
-                AppConstants.isDevBuild() ||
-                AppConstants.isFirebaseBuild()
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val target_sdk = 30
     const val compile_sdk = 31
     const val version_code = 1
-    const val version_name = "2.7.0"
+    const val version_name = "2.7.1"
     const val android_gradle_plugin = "7.0.3"
     const val gms_oss_licenses_plugin = "0.10.4"
     const val support = "1.0.0"


### PR DESCRIPTION
```
Fatal Exception: java.lang.ClassCastException
org.mozilla.rocket.privately.browse.BrowserFragmentLegacy cannot be cast to org.mozilla.rocket.browser.BrowserFragment
org.mozilla.rocket.privately.PrivateModeActivity.getBrowserScreen (PrivateModeActivity.kt:333)
org.mozilla.focus.navigation.ScreenNavigator.getBrowserScreen (ScreenNavigator.kt:181)
org.mozilla.focus.navigation.ScreenNavigator.showBrowserScreen (ScreenNavigator.kt:83)
org.mozilla.rocket.privately.PrivateModeActivity.observeChromeAction$lambda-6 (PrivateModeActivity.kt:173)
org.mozilla.rocket.privately.PrivateModeActivity.$r8$lambda$B-joiRFG_zpDJNbJ8TyQn5DGACQ
org.mozilla.rocket.privately.PrivateModeActivity$$ExternalSyntheticLambda13.onChanged (來源不明:4)
org.mozilla.rocket.download.SingleLiveEvent$1.onChanged (SingleLiveEvent.java:58)
androidx.lifecycle.LiveData.considerNotify (LiveData.java:133)
androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java:50)
org.mozilla.rocket.download.SingleLiveEvent.setValue (SingleLiveEvent.java:85)
org.mozilla.focus.urlinput.UrlInputFragment.openUrl (UrlInputFragment.kt:362)
org.mozilla.focus.urlinput.UrlInputFragment.search (UrlInputFragment.kt:343)
org.mozilla.focus.urlinput.UrlInputFragment.onCommit (UrlInputFragment.kt:322)
org.mozilla.focus.urlinput.UrlInputFragment.access$onCommit (UrlInputFragment.kt:64)
org.mozilla.focus.urlinput.UrlInputFragment$onCreateView$1$2.invoke (UrlInputFragment.kt:118)
org.mozilla.focus.urlinput.UrlInputFragment$onCreateView$1$2.invoke (UrlInputFragment.kt:118)
mozilla.components.ui.autocomplete.InlineAutocompleteEditText$onKey$1.invoke (InlineAutocompleteEditText.kt:195)
mozilla.components.ui.autocomplete.InlineAutocompleteEditText$onKey$1.invoke (InlineAutocompleteEditText.kt:88)
mozilla.components.ui.autocomplete.InlineAutocompleteEditTextKt$sam$android_view_View_OnKeyListener$0.onKey (來源不明:6)
android.view.View.dispatchKeyEvent (View.java:14327)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1016) 
```