### PR TITLE
Fix/session not initialized

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
+++ b/app/src/main/java/org/mozilla/rocket/browser/SessionController.kt
@@ -152,6 +152,11 @@ class SessionController(private val browserFragment: BrowserFragment) : Lifecycl
     }
 
     fun getFocusSession(): Session? {
+        // TODO: Temporally workaround it.
+        // Should check the why the call sequence doesn't make sure it be initialized
+        if (!this::sessionManager.isInitialized) {
+            return null
+        }
         return sessionManager.focusSession
     }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@ object Versions {
     const val target_sdk = 30
     const val compile_sdk = 31
     const val version_code = 1
-    const val version_name = "2.7.1"
+    const val version_name = "2.7.2"
     const val android_gradle_plugin = "7.0.3"
     const val gms_oss_licenses_plugin = "0.10.4"
     const val support = "1.0.0"


### PR DESCRIPTION
I am not sure how to reproduce it so just adding a checking first. May need further investigation on it.

```
Fatal Exception: java.lang.RuntimeException
Unable to start activity ComponentInfo{dev.rocketscientists.rocket/org.mozilla.focus.activity.MainActivity}: kotlin.UninitializedPropertyAccessException: lateinit property sessionManager has not been initialized
android.app.ActivityThread.performLaunchActivity (ActivityThread.java:2955)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
Caused by kotlin.UninitializedPropertyAccessException
lateinit property sessionManager has not been initialized
org.mozilla.rocket.browser.SessionController.getFocusSession (SessionController.kt:155)
org.mozilla.rocket.browser.BrowserFragment.goBackground (BrowserFragment.kt:259)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.setBrowserForegroundState (TransactionHelper.kt:289)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.setBrowserState$lambda-1 (TransactionHelper.kt:265)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.$r8$lambda$0pPT3174TqJ1i94HEaeY_XQh0fw
org.mozilla.focus.navigation.TransactionHelper$BackStackListener$$ExternalSyntheticLambda0.run (來源不明:4)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.executeStateRunnable (TransactionHelper.kt:295)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.setBrowserState (TransactionHelper.kt:269)
org.mozilla.focus.navigation.TransactionHelper$BackStackListener.onBackStackChanged (TransactionHelper.kt:242)
androidx.fragment.app.FragmentManager.reportBackStackChanged (FragmentManager.java:2562)
androidx.appcompat.app.AppCompatActivity.onStart (AppCompatActivity.java:246)
org.mozilla.focus.activity.MainActivity.onStart (MainActivity.kt:469)
android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1340)
com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374) 
```