### PR TITLE
Fix the IllegalStateException happening when user opened the Settings at the first app launch

### DIFF
--- a/app/src/main/java/org/mozilla/rocket/preference/DataSavingPathPreference.kt
+++ b/app/src/main/java/org/mozilla/rocket/preference/DataSavingPathPreference.kt
@@ -44,7 +44,6 @@ class DataSavingPathPreference @JvmOverloads constructor(
         }
         if (TextUtils.isEmpty(entry)) {
             val entries = context.resources.getStringArray(R.array.data_saving_path_entries)
-            setValueIndex(0)
             return entries[0]
         }
         return entry
@@ -55,6 +54,10 @@ class DataSavingPathPreference @JvmOverloads constructor(
         val values = context.resources.getStringArray(R.array.data_saving_path_values)
         setEntries(entries)
         entryValues = values
+
+        if (TextUtils.isEmpty(entry)) {
+            setValueIndex(0)
+        }
     }
 
     @WorkerThread


### PR DESCRIPTION
Reproduce steps:
1. Reinstall app or clear app data
2. Tap menu button in home screen
3. Open Settings

Crash call stacks:
```
Fatal Exception: java.lang.IllegalStateException
Cannot call this method while RecyclerView is computing a layout or scrolling androidx.recyclerview.widget.RecyclerView{52edc72 VFED.V... .F....ID 0,0-1080,2075 #7f09024b app:id/recycler_view}, adapter:androidx.preference.PreferenceGroupAdapter@8237b88, layout:androidx.recyclerview.widget.LinearLayoutManager@9ef3921, context:org.mozilla.rocket.settings.SettingsActivity@9548d13
androidx.recyclerview.widget.RecyclerView.assertNotInLayoutOrScroll (RecyclerView.java:3185)
androidx.recyclerview.widget.RecyclerView$RecyclerViewDataObserver.onItemRangeChanged (RecyclerView.java:5712)
androidx.recyclerview.widget.RecyclerView$AdapterDataObservable.notifyItemRangeChanged (RecyclerView.java:12674)
androidx.recyclerview.widget.RecyclerView$Adapter.notifyItemChanged (RecyclerView.java:7626)
androidx.preference.PreferenceGroupAdapter.onPreferenceChange (PreferenceGroupAdapter.java:351)
androidx.preference.Preference.notifyChanged (Preference.java:1275)
androidx.preference.ListPreference.setValue (ListPreference.java:192)
androidx.preference.ListPreference.setValueIndex (ListPreference.java:240)
org.mozilla.rocket.preference.DataSavingPathPreference.getSummary (DataSavingPathPreference.kt:47)
androidx.preference.Preference.onBindViewHolder (Preference.java:510)
...
```